### PR TITLE
TT-49 user entity 생성

### DIFF
--- a/src/main/java/com/twentythree/peech/user/UserEntity.java
+++ b/src/main/java/com/twentythree/peech/user/UserEntity.java
@@ -1,0 +1,40 @@
+package com.twentythree.peech.user;
+
+import com.twentythree.peech.common.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Entity
+@Table(name = "USER")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(name = "device_id", unique=true)
+    private String device_id;
+
+    public UserEntity ofNoLogin(Long id, String device_id) {
+        return new UserEntity(id, device_id);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserEntity user)) return false;
+        return Objects.equals(id, user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}


### PR DESCRIPTION
PK를 user_id로 가지고 unique한 device값을 가지는 user entity를 생성
로그인 기능이 생길 때를 대비하여 factory method 패턴으로 생성자를 대신함
hashcode와 equals 수정

추가로 여러 entity가 생성될 때 연관관계를 설정해줘야 함