### PR TITLE
feat: TT-74  생성시간만 저장되는 entity 생성

### DIFF
--- a/src/main/java/com/twentythree/peech/common/domain/BaseCreatedAtEntity.java
+++ b/src/main/java/com/twentythree/peech/common/domain/BaseCreatedAtEntity.java
@@ -1,0 +1,19 @@
+package com.twentythree.peech.common.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseCreatedAtEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDate createdAt;
+
+}


### PR DESCRIPTION
일부 테이블의 경우, 수정이 이루어지지 않기에 수정 시간 정보가 필요없음. 그래서 생성시간만 저장되는 entity를 따로 만들어줌