### PR TITLE
TT-50 SCRIPT entity

### DIFF
--- a/src/main/java/com/twentythree/peech/script/domain/STTScriptSubEntity.java
+++ b/src/main/java/com/twentythree/peech/script/domain/STTScriptSubEntity.java
@@ -1,0 +1,14 @@
+package com.twentythree.peech.script.domain;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+import java.time.LocalTime;
+
+@DiscriminatorValue("stt")
+@Entity
+public class STTScriptSubEntity extends ScriptSuperEntity {
+    private LocalTime total_real_time;
+}
+

--- a/src/main/java/com/twentythree/peech/script/domain/ScriptSubEntity.java
+++ b/src/main/java/com/twentythree/peech/script/domain/ScriptSubEntity.java
@@ -1,0 +1,11 @@
+package com.twentythree.peech.script.domain;
+
+import jakarta.persistence.*;
+
+import java.time.LocalTime;
+
+@DiscriminatorValue("input")
+@Entity
+public class ScriptSubEntity extends ScriptSuperEntity {
+    private LocalTime total_expect_time;
+}

--- a/src/main/java/com/twentythree/peech/script/domain/ScriptSuperEntity.java
+++ b/src/main/java/com/twentythree/peech/script/domain/ScriptSuperEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 
 @Entity
+@Table(name = "SCRIPT")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "DType")
 @Getter

--- a/src/main/java/com/twentythree/peech/script/domain/ScriptSuperEntity.java
+++ b/src/main/java/com/twentythree/peech/script/domain/ScriptSuperEntity.java
@@ -1,0 +1,26 @@
+package com.twentythree.peech.script.domain;
+
+import com.twentythree.peech.common.domain.BaseCreatedAtEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "DType")
+@Getter
+public class ScriptSuperEntity extends BaseCreatedAtEntity {
+    @Id
+    @Column(name = "script_id")
+    private Long scriptId;
+
+    @JoinColumns(value = {
+            @JoinColumn(name = "major_vesion"),
+            @JoinColumn(name = "minor_version")
+    })
+    private VersionPk versionFk;
+
+    @Column(name = "script_content", nullable = false )
+    private String scriptContent;
+
+
+}


### PR DESCRIPTION
super/sub 테이블을 이용하며 super 테이블을 PK를 script id로 하고 대본, 생성시간, 입력/음성(dtype), FK를 major, minor version으로 함,sub 테이블은 입력 또는 음성으로 나누어져 예상시간과 측정시간으로 나누어진 컬럼을 가진다.