### PR TITLE
TT-291 대본 수정시 redis에 유저의 문장id정보가 마지막 하나만 저장되는 버그

### DIFF
--- a/src/main/java/com/twentythree/peech/script/cache/CacheService.java
+++ b/src/main/java/com/twentythree/peech/script/cache/CacheService.java
@@ -12,6 +12,8 @@ public interface CacheService {
 
     void rightPushSentenceIdList(String userKey, List<String> sentenceIds);
 
+    void delete(String key);
+
     List<String> findAllByUserKey(String userKey);
 
     RedisSentenceDTO findByKey(String sentenceId);

--- a/src/main/java/com/twentythree/peech/script/cache/CacheService.java
+++ b/src/main/java/com/twentythree/peech/script/cache/CacheService.java
@@ -10,6 +10,8 @@ public interface CacheService {
     // 문장 정보를 저장
     void saveSentenceInformation(String sentenceId, RedisSentenceDTO redisSentence);
 
+    void rightPushSentenceIdList(String userKey, List<String> sentenceIds);
+
     List<String> findAllByUserKey(String userKey);
 
     RedisSentenceDTO findByKey(String sentenceId);

--- a/src/main/java/com/twentythree/peech/script/cache/RedisTemplateImpl.java
+++ b/src/main/java/com/twentythree/peech/script/cache/RedisTemplateImpl.java
@@ -90,6 +90,11 @@ public class RedisTemplateImpl implements CacheService {
     }
 
     @Override
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+
+    @Override
     public List<String> findAllByUserKey(String userKey) {
 
         List<String> list = Optional.ofNullable(redisTemplate.opsForList().range(userKey, 0, -1))

--- a/src/main/java/com/twentythree/peech/script/service/ScriptService.java
+++ b/src/main/java/com/twentythree/peech/script/service/ScriptService.java
@@ -3,6 +3,7 @@ package com.twentythree.peech.script.service;
 import com.twentythree.peech.common.dto.request.GPTRequest;
 import com.twentythree.peech.common.dto.response.GPTResponse;
 import com.twentythree.peech.script.cache.CacheService;
+import com.twentythree.peech.script.cache.RedisTemplateImpl;
 import com.twentythree.peech.script.domain.*;
 import com.twentythree.peech.script.dto.*;
 import com.twentythree.peech.script.dto.response.MajorScriptsResponseDTO;
@@ -33,6 +34,7 @@ import static com.twentythree.peech.common.utils.ScriptUtils.*;
 @Transactional(readOnly = true)
 public class ScriptService {
 
+    private final RedisTemplateImpl redisTemplateImpl;
     @Value("${gpt.model}")
     private String model;
 
@@ -171,6 +173,7 @@ public class ScriptService {
             }
         }
         log.info("redisAllSentencesPerParagraphId: {}", redisAllSentencesPerParagraphId);
+        redisTemplateImpl.delete("user"+userId); // redis에 저장된 문장들을 삭제, 밑에 새로 저장하는 부분에서 값을 다시 채워준다.
         // end: redis에서 user가 수정 할 수 있는 문장들을 가져온뒤 문단별로 합치기
 
         List<ModifiedParagraphDTO> modifiedParagraphListForResponseDTO = new ArrayList<>();

--- a/src/main/java/com/twentythree/peech/script/service/ScriptService.java
+++ b/src/main/java/com/twentythree/peech/script/service/ScriptService.java
@@ -299,7 +299,9 @@ public class ScriptService {
             // start: 변화 사항을 redis에 반영 및 덮어쓰기
 
             List<String> newSentenceIds = new ArrayList<>();
+            log.info("temporaryRedisList: {}", temporaryRedisList);
 
+            // start: key: sentenceId, value: RedisSentenceDTO 로 저장
             for (Map.Entry<SentenceId, RedisSentenceDTO> redisSentenceMap : temporaryRedisList.entrySet()) {
                 String newSentenceId = redisSentenceMap.getKey().getSentenceId();
                 RedisSentenceDTO newSentence = redisSentenceMap.getValue();
@@ -307,9 +309,14 @@ public class ScriptService {
                 log.info("redisSentenceMap: {}", redisSentenceMap);
                 scriptRedisRepository.saveSentenceInformation(newSentenceId, newSentence);
                 newSentenceIds.add(newSentenceId);
-
             }
-            scriptRedisRepository.saveSentencesIdList("user"+userId, newSentenceIds);
+            // end: key: sentenceId, value: RedisSentenceDTO 로 저장
+
+            // start: key: user+userId, value: sentenceId 로 저장
+            log.info("newSentenceIds: {}", newSentenceIds);
+            scriptRedisRepository.rightPushSentenceIdList("user"+userId, newSentenceIds);
+            // end: key: user+userId, value: sentenceId 로 저장
+
             // end: 변화 사항을 redis에 반영 및 덮어쓰기
             
         }


### PR DESCRIPTION
기존의 "user{userId}"를 키로 가지는 리스트에서
문장을 수정 했을 때
수정한 문장 아이디들로 바뀌게 만들어야 하는데
기존에는 초기화 하는 dao 밖에 없어서
redis list에 right push하는 로직을 생성하여 문제를 해결
