### PR TITLE
TT-304 예상 시간 / 3

### DIFF
--- a/src/main/java/com/twentythree/peech/common/utils/ScriptUtils.java
+++ b/src/main/java/com/twentythree/peech/common/utils/ScriptUtils.java
@@ -11,7 +11,7 @@ public class ScriptUtils {
         int wordsCount = words.length;
 
         float expectedTimeToSecond = wordsCount * DEFAULT_TIME_PER_WORD_SECOND;
-
+        expectedTimeToSecond /= 3f;
         LocalTime expectedTime = transferSeoondToLocalTime(expectedTimeToSecond);
 
         return expectedTime;


### PR DESCRIPTION
예상 시간이 너무 길게 나오는 상황에서 적절한 시간과 약 3배 정도의 차이를 보이는 경향이 나탐, 따라서 하드코딩으로 /3을 임시로 함