### PR TITLE
TT-323 최대 녹음 시간 변경 및 여유 시간 설정

### DIFF
--- a/src/main/java/com/twentythree/peech/usagetime/constant/ConstantValue.java
+++ b/src/main/java/com/twentythree/peech/usagetime/constant/ConstantValue.java
@@ -5,6 +5,6 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ConstantValue {
-    public static final Long MAX_AUDIO_TIME = 600L;
+    public static final Long MAX_AUDIO_TIME = 900L;
     public static final Long BUFFER_TIME = 5L;
 }

--- a/src/main/java/com/twentythree/peech/usagetime/service/UsageTimeService.java
+++ b/src/main/java/com/twentythree/peech/usagetime/service/UsageTimeService.java
@@ -22,7 +22,10 @@ import org.xml.sax.SAXException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.channels.IllegalChannelGroupException;
 import java.time.LocalTime;
+
+import static com.twentythree.peech.usagetime.constant.ConstantValue.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -112,6 +115,11 @@ public class UsageTimeService {
     }
 
     public CheckRemainingTimeResponseDTO checkRemainingTime(Long userId, Long audioTime) {
+
+        if (audioTime > MAX_AUDIO_TIME + BUFFER_TIME) {
+            throw new IllegalArgumentException("최대 사용 시간을 초과하였습니다.");
+        }
+
         UsageTimeEntity usageTime = usageTimeRepository.findByUserId(userId).
                 orElseThrow(() -> new IllegalArgumentException("사용자 아이디가 잘 못 되었습니다."));
         Long remainingTime = usageTime.getRemainingTime();
@@ -119,7 +127,7 @@ public class UsageTimeService {
     }
 
     public TextAndSecondResponseDTO getMaxAudioTime() {
-        Long maxAudioTimeToSecond = ConstantValue.MAX_AUDIO_TIME + ConstantValue.BUFFER_TIME;
+        Long maxAudioTimeToSecond = MAX_AUDIO_TIME;
         LocalTime maxAudioTimeToLocalTime = ScriptUtils.transferSeoondToLocalTime(maxAudioTimeToSecond);
 
         int hour = maxAudioTimeToLocalTime.getHour();


### PR DESCRIPTION
클라이언트가 최대 녹음 가능 시간을 요청하면 900초를 응답한다.

클라이언트가 실제로 음성시간을  905초까지 보내도 사용 가능을 응답한다.