### PR TITLE
fix: TT-290 시간 표시 법 변경

### DIFF
--- a/src/main/java/com/twentythree/peech/common/utils/ScriptUtils.java
+++ b/src/main/java/com/twentythree/peech/common/utils/ScriptUtils.java
@@ -24,7 +24,8 @@ public class ScriptUtils {
         int hour = second / 3600;
         int minute = (second % 3600) / 60;
         int secondSet = (second % 3600) % 60;
-        int milliSecond = (int) ((time - second) * 1_000_000_000);
+        int milliSecond = ((int)((time-second)*100)) * 10_000_000;
+
         return LocalTime.of(hour, minute, secondSet, milliSecond);
     }
 

--- a/src/test/java/com/twentythree/peech/common/utils/ScriptUtilsTest.java
+++ b/src/test/java/com/twentythree/peech/common/utils/ScriptUtilsTest.java
@@ -1,0 +1,21 @@
+package com.twentythree.peech.common.utils;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+class ScriptUtilsTest {
+
+    @Test
+    public void 초를_시간으로_변환하는_로직_테스트() throws Exception {
+        //Given
+        float second = 600.194328971244f;
+
+        //When
+        LocalTime localTime = ScriptUtils.transferSeoondToLocalTime(second);
+
+        //Then
+        Assertions.assertThat(localTime).isEqualTo(LocalTime.of(0, 10, 0, 190_000_000));
+    }
+}


### PR DESCRIPTION
시간에 milesecond를 표시
milesecond는 2자리 까지만 표시