### PR TITLE
TT-329 user delete

### DIFF
--- a/src/main/java/com/twentythree/peech/common/utils/TimeUtils.java
+++ b/src/main/java/com/twentythree/peech/common/utils/TimeUtils.java
@@ -1,0 +1,14 @@
+package com.twentythree.peech.common.utils;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class TimeUtils {
+
+    public static LocalDate CreateNowUTC() {
+        ZoneId nowUTC = ZoneId.of("Z");
+        ZonedDateTime zonedDateTime = ZonedDateTime.now(nowUTC);
+        return zonedDateTime.toLocalDate();
+    }
+}

--- a/src/main/java/com/twentythree/peech/user/UserRole.java
+++ b/src/main/java/com/twentythree/peech/user/UserRole.java
@@ -1,5 +1,5 @@
 package com.twentythree.peech.user;
 
 public enum UserRole {
-    COMMON, ADMIN
+    ROLE_COMMON, ROLE_ADMIN
 }

--- a/src/main/java/com/twentythree/peech/user/controller/UserController.java
+++ b/src/main/java/com/twentythree/peech/user/controller/UserController.java
@@ -1,21 +1,22 @@
 package com.twentythree.peech.user.controller;
 
+import com.twentythree.peech.user.domain.UserDomain;
+import com.twentythree.peech.user.domain.UserMapper;
 import com.twentythree.peech.user.dto.AccessAndRefreshToken;
 import com.twentythree.peech.user.dto.request.CreateUserRequestDTO;
+import com.twentythree.peech.user.dto.response.UserDeleteResponseDTO;
 import com.twentythree.peech.user.dto.response.UserIdTokenResponseDTO;
 import com.twentythree.peech.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
 public class UserController implements SwaggerUserController{
 
     private final UserService userService;
+    private final UserMapper userMapper;
 
     @Operation(summary = "유저 가입",
             description = "deviceId를 RequestBody에 담아 요청하면 새로운 유저를 생성하고 생성된 UserId를 응답한다.")
@@ -43,5 +44,15 @@ public class UserController implements SwaggerUserController{
     public UserIdTokenResponseDTO reIssuanceUserToken(@RequestBody CreateUserRequestDTO request) {
         String token = userService.reIssuanceUserToken(request.getDeviceId());
         return new UserIdTokenResponseDTO(token, token);
+    }
+
+    @Operation(summary = "유저 삭제")
+    @DeleteMapping("api/v2/user")
+    public UserDeleteResponseDTO deleteUser() {
+        // TODO 유저 토큰에서 userId 가져오는 코드
+        Long userId = 123L; // 임시 유저
+        UserDomain userDomain = userService.deleteUser(userId);
+        userMapper.saveUserDomain(userDomain);
+        return new UserDeleteResponseDTO(userDomain.getDeleteAt());
     }
 }

--- a/src/main/java/com/twentythree/peech/user/domain/UserCreator.java
+++ b/src/main/java/com/twentythree/peech/user/domain/UserCreator.java
@@ -17,7 +17,7 @@ public class UserCreator {
 
     public UserDomain createUser(AuthorizationIdentifier authorizationIdentifier, String firstName, String lastName, LocalDate birth, String email, UserGender gender, String nickName) {
         if ( userValidator.NickNameIsNotDuplicated(nickName) ) {
-            return UserDomain.of( authorizationIdentifier,  firstName, lastName, birth, gender, email, nickName);
+            return UserDomain.ofCreateUser( authorizationIdentifier,  firstName, lastName, birth, gender, email, nickName);
         } else {
             throw new IllegalArgumentException("닉네임이 중복 되었습니다 : " + nickName);
         }

--- a/src/main/java/com/twentythree/peech/user/domain/UserDeleter.java
+++ b/src/main/java/com/twentythree/peech/user/domain/UserDeleter.java
@@ -1,0 +1,18 @@
+package com.twentythree.peech.user.domain;
+
+import com.twentythree.peech.common.utils.TimeUtils;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+public class UserDeleter {
+
+    public LocalDate deleteUser(UserDomain userDomain) {
+        userDomain.changeUserStatusToDelete();
+
+        LocalDate nowUTC = TimeUtils.CreateNowUTC();
+
+        return userDomain.setDeleteAt(nowUTC);
+    }
+}

--- a/src/main/java/com/twentythree/peech/user/domain/UserDomain.java
+++ b/src/main/java/com/twentythree/peech/user/domain/UserDomain.java
@@ -55,7 +55,7 @@ public class UserDomain {
     public static UserDomain ofCreateUser(AuthorizationIdentifier authorizationIdentifier, String firstName,
                                           String lastName, LocalDate birth, UserGender gender,
                                           String email, String nickName){
-        return new UserDomain(authorizationIdentifier, firstName, lastName, birth, gender, email, nickName, UserRole.COMMON, DEFAULT_USAGE_TIME, DEFAULT_USAGE_TIME);
+        return new UserDomain(authorizationIdentifier, firstName, lastName, birth, gender, email, nickName, UserRole.ROLE_COMMON, DEFAULT_USAGE_TIME, DEFAULT_USAGE_TIME);
     }
 
 

--- a/src/main/java/com/twentythree/peech/user/domain/UserDomain.java
+++ b/src/main/java/com/twentythree/peech/user/domain/UserDomain.java
@@ -3,16 +3,17 @@ package com.twentythree.peech.user.domain;
 import com.twentythree.peech.user.AuthorizationIdentifier;
 import com.twentythree.peech.user.UserGender;
 import com.twentythree.peech.user.UserRole;
+import com.twentythree.peech.user.UserStatus;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDate;
-import java.util.Objects;
 
 import static com.twentythree.peech.usagetime.constant.UsageConstantValue.DEFAULT_USAGE_TIME;
 
 @Getter
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserDomain {
 
     private Long userId;
@@ -24,9 +25,11 @@ public class UserDomain {
     private String email;
     private String nickName;
     private UserRole role;
+    private UserStatus userStatus;
 
     private Long usageTime;
     private Long remainingTime;
+    private LocalDate deleteAt;
 
     private UserDomain(AuthorizationIdentifier authorizationIdentifier, String firstName, String lastName,
                        LocalDate birth, UserGender gender, String email,
@@ -43,9 +46,25 @@ public class UserDomain {
         this.remainingTime = remainingTime;
     }
 
-    public static UserDomain of(AuthorizationIdentifier authorizationIdentifier, String firstName,
+    public static UserDomain of(Long userId, AuthorizationIdentifier authorizationIdentifier, String firstName,
                                 String lastName, LocalDate birth, UserGender gender,
-                                String email, String nickName){
+                                String email, String nickName, UserRole role, UserStatus userStatus, Long usageTime, Long remainingTime, LocalDate deleteAt){
+        return new UserDomain(userId, authorizationIdentifier, firstName, lastName, birth, gender, email, nickName, role, userStatus, usageTime, remainingTime, deleteAt);
+    }
+
+    public static UserDomain ofCreateUser(AuthorizationIdentifier authorizationIdentifier, String firstName,
+                                          String lastName, LocalDate birth, UserGender gender,
+                                          String email, String nickName){
         return new UserDomain(authorizationIdentifier, firstName, lastName, birth, gender, email, nickName, UserRole.COMMON, DEFAULT_USAGE_TIME, DEFAULT_USAGE_TIME);
+    }
+
+
+    public void changeUserStatusToDelete() {
+        this.userStatus = UserStatus.DELETE;
+    }
+
+    public LocalDate setDeleteAt(LocalDate deleteAt) {
+        this.deleteAt = deleteAt;
+        return this.deleteAt;
     }
 }

--- a/src/main/java/com/twentythree/peech/user/domain/UserFetcher.java
+++ b/src/main/java/com/twentythree/peech/user/domain/UserFetcher.java
@@ -1,0 +1,24 @@
+package com.twentythree.peech.user.domain;
+
+import com.twentythree.peech.usagetime.domain.UsageTimeEntity;
+import com.twentythree.peech.usagetime.repository.UsageTimeRepository;
+import com.twentythree.peech.user.entity.UserEntity;
+import com.twentythree.peech.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class UserFetcher {
+
+    private final UserRepository userRepository;
+    private final UsageTimeRepository usageTimeRepository;
+
+    public UserDomain fetchUser(Long userId){
+
+        UserEntity user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("잘 못된 유저 정보입니다."));
+        UsageTimeEntity usageTime = usageTimeRepository.findByUserId(userId).orElseThrow(() -> new IllegalArgumentException("잘 못된 유저 정보 입니다."));
+
+        return UserDomain.of(user.getId(), user.getAuthorizationIdentifier(), user.getFirstName(), user.getLastName(), user.getBirth(), user.getGender(), user.getEmail(), user.getNickName(), user.getRole(), user.getUserStatus(), usageTime.getUsageTimeId(), usageTime.getRemainingTime(), user.getDeleteAt());
+    }
+}

--- a/src/main/java/com/twentythree/peech/user/dto/response/UserDeleteResponseDTO.java
+++ b/src/main/java/com/twentythree/peech/user/dto/response/UserDeleteResponseDTO.java
@@ -1,0 +1,13 @@
+package com.twentythree.peech.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class UserDeleteResponseDTO {
+    private LocalDate deleteAt;
+
+}

--- a/src/main/java/com/twentythree/peech/user/entity/UserEntity.java
+++ b/src/main/java/com/twentythree/peech/user/entity/UserEntity.java
@@ -53,7 +53,7 @@ public class UserEntity extends BaseTimeEntity {
     private String nickName;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "role", nullable = false) @ColumnDefault("'COMMON'")
+    @Column(name = "role", nullable = false) @ColumnDefault("'ROLE_COMMON'")
     private UserRole role;
 
     @Enumerated(EnumType.STRING)
@@ -73,7 +73,7 @@ public class UserEntity extends BaseTimeEntity {
     }
 
     public static UserEntity of(Long id, String deviceId, AuthorizationIdentifier authorizationIdentifier, String firstName, String lastName, LocalDate birth, UserGender gender, String email, String nickName) {
-        return new UserEntity(id, authorizationIdentifier, deviceId, firstName, lastName, birth, gender, email, nickName, UserRole.COMMON, UserStatus.ACTIVE, null);
+        return new UserEntity(id, authorizationIdentifier, deviceId, firstName, lastName, birth, gender, email, nickName, UserRole.ROLE_COMMON, UserStatus.ACTIVE, null);
     }
 
     @Override

--- a/src/main/java/com/twentythree/peech/user/entity/UserEntity.java
+++ b/src/main/java/com/twentythree/peech/user/entity/UserEntity.java
@@ -60,6 +60,9 @@ public class UserEntity extends BaseTimeEntity {
     @Column(name = "user_status", nullable = false) @ColumnDefault("'ACTIVE'")
     private UserStatus userStatus;
 
+    @Column(name = "delete_at")
+    private LocalDate deleteAt;
+
 
     public UserEntity(String device_id) {
         this.deviceId = device_id;
@@ -70,7 +73,7 @@ public class UserEntity extends BaseTimeEntity {
     }
 
     public static UserEntity of(Long id, String deviceId, AuthorizationIdentifier authorizationIdentifier, String firstName, String lastName, LocalDate birth, UserGender gender, String email, String nickName) {
-        return new UserEntity(id, authorizationIdentifier, deviceId, firstName, lastName, birth, gender, email, nickName, UserRole.COMMON, UserStatus.ACTIVE);
+        return new UserEntity(id, authorizationIdentifier, deviceId, firstName, lastName, birth, gender, email, nickName, UserRole.COMMON, UserStatus.ACTIVE, null);
     }
 
     @Override

--- a/src/main/java/com/twentythree/peech/user/service/UserService.java
+++ b/src/main/java/com/twentythree/peech/user/service/UserService.java
@@ -4,6 +4,7 @@ package com.twentythree.peech.user.service;
 import com.twentythree.peech.common.exception.UserAlreadyExistException;
 import com.twentythree.peech.user.AuthorizationServer;
 import com.twentythree.peech.user.UserGender;
+import com.twentythree.peech.user.domain.UserDomain;
 import com.twentythree.peech.user.dto.AccessAndRefreshToken;
 
 import java.time.LocalDate;
@@ -12,4 +13,5 @@ public interface UserService {
     String createUserByDeviceId(String deviceId) throws UserAlreadyExistException;
     String reIssuanceUserToken(String deviceId);
     AccessAndRefreshToken createUserBySocial(String socialId, AuthorizationServer authorizationServer, String firstName, String lastName, LocalDate birth, String email, UserGender gender, String nickName);
+    UserDomain deleteUser(Long userId);
 }

--- a/src/main/java/com/twentythree/peech/user/service/UserServiceImpl.java
+++ b/src/main/java/com/twentythree/peech/user/service/UserServiceImpl.java
@@ -8,9 +8,7 @@ import com.twentythree.peech.user.AuthorizationIdentifier;
 import com.twentythree.peech.user.AuthorizationServer;
 import com.twentythree.peech.user.UserGender;
 import com.twentythree.peech.user.UserRole;
-import com.twentythree.peech.user.domain.UserCreator;
-import com.twentythree.peech.user.domain.UserDomain;
-import com.twentythree.peech.user.domain.UserMapper;
+import com.twentythree.peech.user.domain.*;
 import com.twentythree.peech.user.dto.AccessAndRefreshToken;
 import com.twentythree.peech.user.entity.UserEntity;
 import com.twentythree.peech.user.repository.UserRepository;
@@ -29,6 +27,8 @@ public class UserServiceImpl implements UserService {
     private final UsageTimeRepository usageTimeRepository;
     private final UserMapper userMapper;
     private final UserCreator userCreator;
+    private final UserFetcher userFetcher;
+    private final UserDeleter userDeleter;
     private final JWTUtils jwtUtils;
 
     @Override
@@ -64,6 +64,13 @@ public class UserServiceImpl implements UserService {
         String refreshToken = jwtUtils.createRefreshToken(userId, userRole);
 
         return new AccessAndRefreshToken(accessToken, refreshToken);
+    }
+
+    @Override
+    public UserDomain deleteUser(Long userId) {
+        UserDomain userDomain = userFetcher.fetchUser(userId);
+        LocalDate deleteAt = userDeleter.deleteUser(userDomain);
+        return userDomain;
     }
 
     @Override

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,5 +1,5 @@
 INSERT INTO user (birth, created_at, updated_at, social_id, user_id, device_id, email, first_name, last_name, nick_name, authorization_server, gender, role, user_status) VALUES
-    ('2018-02-01', '2018-02-01', '2018-12-18', '124123123', '1', 'device_1', 'asdf@naver.com', 'ex', 'ample', 'nick', 'KAKAO', 'MALE', 'COMMON', 'ACTIVE');
+    ('2018-02-01', '2018-02-01', '2018-12-18', '124123123', '1', 'device_1', 'asdf@naver.com', 'ex', 'ample', 'nick', 'KAKAO', 'MALE', 'ROLE_COMMON', 'ACTIVE');
 
 INSERT INTO usage_time(usage_time_id, user_id, created_at, updated_at, remaining_time) VALUES
     (1, 1, '2018-02-01', '2018-12-18', '9000');


### PR DESCRIPTION
ZondId를 이용해 UTC 시간을 받아오고 LocalDate로 변환

유저 db entity 에 유저 삭제 일 column을 추가
유저 도메인 엔티티에 삭제일 추가 및 유저생성에 필요한 정보만 받는 ofCreateUser와 모든 정보를 받는 of 팩토리 메소드로 분리
유저를 처음 생성할때 필요한 정보들만 채우는 ofCreateUser로 변경
db에서 user와 usageTime 정보를 가져와 userDomain으로 바꾸는 fetcher를 구현
삭제 하고자 하는 유저를 받아와 유저 상태를 삭제로 변경후 삭제 일을 당일 UTC 시간으로 기록
유저 아이디로 유저 도메인을 fetch하고 userDeleter를 실행
api/v2/user로 delete 메소드를 보내면 유저를 삭제
유저 아이디는 accesstoken에서 가져와야 함으로 후에 추가
