### PR TITLE
TT-328 create user 흐름 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,17 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('springCloudVersion', "2023.0.1")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     compileOnly 'org.projectlombok:lombok'
@@ -64,6 +75,9 @@ dependencies {
     //WebClient
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     runtimeOnly("io.netty:netty-resolver-dns-native-macos:4.2.0.Alpha1:osx-aarch_64")
+
+    //FeignClinet
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     //Tika
     implementation 'org.apache.tika:tika-core:2.4.1'

--- a/src/main/java/com/twentythree/peech/common/utils/JWTUtils.java
+++ b/src/main/java/com/twentythree/peech/common/utils/JWTUtils.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.util.Base64;
+import java.util.Date;
 
 @RequiredArgsConstructor
 @Component
@@ -27,6 +28,12 @@ public class JWTUtils {
     private SecretKey secretKey;
     private SecretKey accessKey;
     private SecretKey refreshKey;
+
+    private Date accessExpirationDate;
+    private Date refreshExpirationDate;
+
+    private final Long accessExpiration = 30L;
+    private final Long refreshExpiration = 60L;
 
 
     @PostConstruct
@@ -44,6 +51,10 @@ public class JWTUtils {
 
         refreshString = Base64.getEncoder().encodeToString(secretString.getBytes());
         this.refreshKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(refreshString));
+
+        Date today = new Date();
+        this.accessExpirationDate = new Date(today.getTime() + (1000 * 60 * 60 * 24 * accessExpiration));
+        this.refreshExpirationDate = new Date(today.getTime() + (1000 * 60 * 60 * 24 * refreshExpiration));
     }
 
 
@@ -64,6 +75,7 @@ public class JWTUtils {
                 subject("AccessToken").
                 claim("userId", userId).
                 claim("userRole", userRole).
+                expiration(accessExpirationDate).
                 signWith(accessKey, Jwts.SIG.HS256).
                 compact();
     }
@@ -75,6 +87,7 @@ public class JWTUtils {
                 subject("RefreshToken").
                 claim("userId", userId).
                 claim("userRole", userRole).
+                expiration(refreshExpirationDate).
                 signWith(refreshKey, Jwts.SIG.HS256).
                 compact();
     }

--- a/src/main/java/com/twentythree/peech/common/utils/JWTUtils.java
+++ b/src/main/java/com/twentythree/peech/common/utils/JWTUtils.java
@@ -1,7 +1,7 @@
 package com.twentythree.peech.common.utils;
 
 import com.twentythree.peech.common.JwtProperties;
-import com.twentythree.peech.user.UserRole;
+import com.twentythree.peech.user.value.UserRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;

--- a/src/main/java/com/twentythree/peech/config/OpenFeignConfig.java
+++ b/src/main/java/com/twentythree/peech/config/OpenFeignConfig.java
@@ -1,0 +1,10 @@
+package com.twentythree.peech.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients("com.twentythree.peech")
+class OpenFeignConfig {
+
+}

--- a/src/main/java/com/twentythree/peech/user/SignUpFinished.java
+++ b/src/main/java/com/twentythree/peech/user/SignUpFinished.java
@@ -1,0 +1,5 @@
+package com.twentythree.peech.user;
+
+public enum SignUpFinished {
+    PENDING, FINISHED
+}

--- a/src/main/java/com/twentythree/peech/user/client/KakaoLoginClient.java
+++ b/src/main/java/com/twentythree/peech/user/client/KakaoLoginClient.java
@@ -2,16 +2,19 @@ package com.twentythree.peech.user.client;
 
 import com.twentythree.peech.user.dto.response.KakaoGetUserEmailResponseDTO;
 import com.twentythree.peech.user.dto.response.KakaoTokenDecodeResponseDTO;
+import feign.Headers;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient(name = "kakaoLoginClient", url = "https://kapi.kakao.com/")
 public interface KakaoLoginClient {
+    final String xfrom = "application/x-www-form-urlencoded;charset=utf-8";
 
     @GetMapping("v1/user/access_token_info")
-    KakaoTokenDecodeResponseDTO decodeToken (@RequestHeader("Authorization") String token);
+    KakaoTokenDecodeResponseDTO decodeToken(@RequestHeader("Authorization") String token);
 
     @GetMapping("v2/user/me?properties_keys=[\"kakao_acount.email\"]")
+    @Headers("application/x-www-form-urlencoded;charset=utf-8")
     KakaoGetUserEmailResponseDTO getUserEmail(@RequestHeader("Authorization") String token);
 }

--- a/src/main/java/com/twentythree/peech/user/client/KakaoLoginClient.java
+++ b/src/main/java/com/twentythree/peech/user/client/KakaoLoginClient.java
@@ -1,0 +1,17 @@
+package com.twentythree.peech.user.client;
+
+import com.twentythree.peech.user.dto.response.KakaoGetUserEmailResponseDTO;
+import com.twentythree.peech.user.dto.response.KakaoTokenDecodeResponseDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "kakaoLoginClient", url = "https://kapi.kakao.com/")
+public interface KakaoLoginClient {
+
+    @GetMapping("v1/user/access_token_info")
+    KakaoTokenDecodeResponseDTO decodeToken (@RequestHeader("Authorization") String token);
+
+    @GetMapping("v2/user/me?properties_keys=[\"kakao_acount.email\"]")
+    KakaoGetUserEmailResponseDTO getUserEmail(@RequestHeader("Authorization") String token);
+}

--- a/src/main/java/com/twentythree/peech/user/controller/UserController.java
+++ b/src/main/java/com/twentythree/peech/user/controller/UserController.java
@@ -1,9 +1,10 @@
 package com.twentythree.peech.user.controller;
 
-import com.twentythree.peech.user.AuthorizationServer;
-import com.twentythree.peech.user.domain.UserDomain;
 import com.twentythree.peech.user.domain.UserMapper;
+import com.twentythree.peech.user.value.AuthorizationServer;
+import com.twentythree.peech.user.domain.UserDomain;
 import com.twentythree.peech.user.dto.AccessAndRefreshToken;
+import com.twentythree.peech.user.dto.request.CompleteProfileRequestDTO;
 import com.twentythree.peech.user.dto.request.CreateUserRequestDTO;
 import com.twentythree.peech.user.dto.request.LoginBySocialRequestDTO;
 import com.twentythree.peech.user.dto.response.UserDeleteResponseDTO;
@@ -47,6 +48,23 @@ public class UserController implements SwaggerUserController{
         return ResponseEntity.status(411).body(new UserIdTokenResponseDTO(accessAndRefreshToken.getAccessToken(), accessAndRefreshToken.getRefreshToken()));
     }
 
+    @Operation(summary = "로그인에 필요한 추가 정보를 입력 받는다",
+            description = "gender는 꼭 입력 받지 않아도 된다.")
+    @PatchMapping("api/v1.1/user")
+    public ResponseEntity<UserIdTokenResponseDTO> completeProfile(@RequestBody CompleteProfileRequestDTO request) {
+        if (request.getFirstName() == null || request.getLastName() == null || request.getBirth() == null || request.getNickName() == null ) {
+            return ResponseEntity.badRequest().build();
+        }
+        //TODO 컨텍스트 홀더에서 유저 아이디 가져오기
+        Long userId = 0L;
+
+        AccessAndRefreshToken accessAndRefreshToken = userService.completeProfile(userId,request.getFirstName(), request.getLastName(), request.getNickName(), request.getBirth(), request.getGender());
+
+        return ResponseEntity.status(200).body(new UserIdTokenResponseDTO(accessAndRefreshToken.getAccessToken(), accessAndRefreshToken.getRefreshToken()));
+    }
+
+
+
     @Operation(summary = "유저 토큰 재발급",
             description = "deviceId를 전송하면 이미 가입된 유저라면 유저 토큰 재발급")
     @Override
@@ -61,8 +79,8 @@ public class UserController implements SwaggerUserController{
     public UserDeleteResponseDTO deleteUser() {
         // TODO 유저 토큰에서 userId 가져오는 코드
         Long userId = 123L; // 임시 유저
+
         UserDomain userDomain = userService.deleteUser(userId);
-        userMapper.saveUserDomain(userDomain);
         return new UserDeleteResponseDTO(userDomain.getDeleteAt());
     }
 }

--- a/src/main/java/com/twentythree/peech/user/controller/UserController.java
+++ b/src/main/java/com/twentythree/peech/user/controller/UserController.java
@@ -1,11 +1,14 @@
 package com.twentythree.peech.user.controller;
 
+import com.twentythree.peech.user.AuthorizationServer;
 import com.twentythree.peech.user.dto.AccessAndRefreshToken;
 import com.twentythree.peech.user.dto.request.CreateUserRequestDTO;
+import com.twentythree.peech.user.dto.request.LoginBySocialRequestDTO;
 import com.twentythree.peech.user.dto.response.UserIdTokenResponseDTO;
 import com.twentythree.peech.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,12 +31,15 @@ public class UserController implements SwaggerUserController{
 
     @Operation(summary = "카카오톡으로 회원 가입",
             description = "카카오 톡으로 회원 가입")
-    @PostMapping("api/v2/user")
-    public UserIdTokenResponseDTO createUserBySocial(@RequestBody CreateUserRequestDTO request) {
+    @PostMapping("api/v1.1/user")
+    public ResponseEntity<UserIdTokenResponseDTO> loginBySocial(@RequestBody LoginBySocialRequestDTO request) {
 
-        AccessAndRefreshToken accessAndRefreshToken = userService.createUserBySocial(request.getSocialId(), request.getAuthorizationServer(), request.getFirstName(), request.getLastName(), request.getBirth(), request.getEmail(), request.getGender(), request.getNickName());
+        String token = request.getSocialToken();
+        AuthorizationServer authorizationServer = request.getAuthorizationServer();
 
-        return new UserIdTokenResponseDTO(accessAndRefreshToken.getAccessToken(), accessAndRefreshToken.getRefreshToken());
+        AccessAndRefreshToken accessAndRefreshToken = userService.loginBySocial(token, authorizationServer);
+        
+        return ResponseEntity.status(411).body(new UserIdTokenResponseDTO(accessAndRefreshToken.getAccessToken(), accessAndRefreshToken.getRefreshToken()));
     }
 
     @Operation(summary = "유저 토큰 재발급",

--- a/src/main/java/com/twentythree/peech/user/controller/UserController.java
+++ b/src/main/java/com/twentythree/peech/user/controller/UserController.java
@@ -29,8 +29,8 @@ public class UserController implements SwaggerUserController{
         return new UserIdTokenResponseDTO(token, token);
     }
 
-    @Operation(summary = "카카오톡으로 회원 가입",
-            description = "카카오 톡으로 회원 가입")
+    @Operation(summary = "소셜로 회원 가입",
+            description = "소셜 계정으로 회원 가입")
     @PostMapping("api/v1.1/user")
     public ResponseEntity<UserIdTokenResponseDTO> loginBySocial(@RequestBody LoginBySocialRequestDTO request) {
 
@@ -38,9 +38,11 @@ public class UserController implements SwaggerUserController{
         AuthorizationServer authorizationServer = request.getAuthorizationServer();
 
         AccessAndRefreshToken accessAndRefreshToken = userService.loginBySocial(token, authorizationServer);
-        
+
         return ResponseEntity.status(411).body(new UserIdTokenResponseDTO(accessAndRefreshToken.getAccessToken(), accessAndRefreshToken.getRefreshToken()));
     }
+
+
 
     @Operation(summary = "유저 토큰 재발급",
             description = "deviceId를 전송하면 이미 가입된 유저라면 유저 토큰 재발급")

--- a/src/main/java/com/twentythree/peech/user/domain/UserCreator.java
+++ b/src/main/java/com/twentythree/peech/user/domain/UserCreator.java
@@ -1,6 +1,9 @@
 package com.twentythree.peech.user.domain;
 
+import com.twentythree.peech.usagetime.constant.UsageConstantValue;
 import com.twentythree.peech.user.AuthorizationIdentifier;
+import com.twentythree.peech.user.SignUpFinished;
+import com.twentythree.peech.user.UserRole;
 import com.twentythree.peech.user.validator.UserValidator;
 import com.twentythree.peech.user.UserGender;
 import lombok.RequiredArgsConstructor;
@@ -21,5 +24,9 @@ public class UserCreator {
         } else {
             throw new IllegalArgumentException("닉네임이 중복 되었습니다 : " + nickName);
         }
+    }
+
+    public UserDomain createUserByEmail(AuthorizationIdentifier authorizationIdentifier, String email, SignUpFinished signUpFinished) {
+        return UserDomain.ofEmail(authorizationIdentifier, email, UserRole.COMMON, UsageConstantValue.DEFAULT_USAGE_TIME, UsageConstantValue.DEFAULT_USAGE_TIME, signUpFinished);
     }
 }

--- a/src/main/java/com/twentythree/peech/user/domain/UserCreator.java
+++ b/src/main/java/com/twentythree/peech/user/domain/UserCreator.java
@@ -1,11 +1,9 @@
 package com.twentythree.peech.user.domain;
 
 import com.twentythree.peech.usagetime.constant.UsageConstantValue;
-import com.twentythree.peech.user.AuthorizationIdentifier;
-import com.twentythree.peech.user.SignUpFinished;
-import com.twentythree.peech.user.UserRole;
+import com.twentythree.peech.user.entity.AuthorizationIdentifier;
+import com.twentythree.peech.user.value.*;
 import com.twentythree.peech.user.validator.UserValidator;
-import com.twentythree.peech.user.UserGender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -28,5 +26,18 @@ public class UserCreator {
 
     public UserDomain createUserByEmail(AuthorizationIdentifier authorizationIdentifier, String email, SignUpFinished signUpFinished) {
         return UserDomain.ofEmail(authorizationIdentifier, email, UserRole.ROLE_COMMON, UsageConstantValue.DEFAULT_USAGE_TIME, UsageConstantValue.DEFAULT_USAGE_TIME, signUpFinished);
+    }
+
+    public UserDomain completeUser(UserDomain userDomain,  AuthorizationIdentifier authorizationIdentifier, String firstName, String lastName, LocalDate birth, UserGender gender, String email, String nickName, UserRole role, UserStatus userStatus, SignUpFinished signUpFinished, LocalDate deleteAt) {
+        if (userValidator.NickNameIsNotDuplicated(nickName) && userDomain.getUserStatus() != UserStatus.DELETE && userStatus != UserStatus.DELETE) {
+            userDomain.setUser(authorizationIdentifier, firstName, lastName, birth, gender, email, nickName, role, userStatus, signUpFinished, deleteAt);
+        } else {
+            if (userDomain.getUserStatus() == UserStatus.DELETE || userStatus == UserStatus.DELETE) {
+                throw new IllegalArgumentException("삭제된 유저는 정보를 변경 할 수 없습니다.");
+            } else {
+                throw new IllegalArgumentException("닉네임이 중복 되었습니다.");
+            }
+        }
+        return userDomain;
     }
 }

--- a/src/main/java/com/twentythree/peech/user/domain/UserDomain.java
+++ b/src/main/java/com/twentythree/peech/user/domain/UserDomain.java
@@ -1,6 +1,7 @@
 package com.twentythree.peech.user.domain;
 
 import com.twentythree.peech.user.AuthorizationIdentifier;
+import com.twentythree.peech.user.SignUpFinished;
 import com.twentythree.peech.user.UserGender;
 import com.twentythree.peech.user.UserRole;
 import lombok.AllArgsConstructor;
@@ -24,6 +25,7 @@ public class UserDomain {
     private String email;
     private String nickName;
     private UserRole role;
+    private SignUpFinished signUpFinished;
 
     private Long usageTime;
     private Long remainingTime;
@@ -43,9 +45,22 @@ public class UserDomain {
         this.remainingTime = remainingTime;
     }
 
+    private UserDomain( AuthorizationIdentifier authorizationIdentifier, String email, UserRole role, Long usageTime, Long remainingTime, SignUpFinished signUpFinished) {
+        this.authorizationIdentifier = authorizationIdentifier;
+        this.email = email;
+        this.role = role;
+        this.usageTime = usageTime;
+        this.remainingTime = remainingTime;
+        this.signUpFinished = signUpFinished;
+    }
+
     public static UserDomain of(AuthorizationIdentifier authorizationIdentifier, String firstName,
                                 String lastName, LocalDate birth, UserGender gender,
                                 String email, String nickName){
         return new UserDomain(authorizationIdentifier, firstName, lastName, birth, gender, email, nickName, UserRole.COMMON, DEFAULT_USAGE_TIME, DEFAULT_USAGE_TIME);
+    }
+
+    public static UserDomain ofEmail(AuthorizationIdentifier authorizationIdentifier, String email, UserRole role, Long usageTime, Long remainingTime, SignUpFinished signUpFinished){
+        return new UserDomain(authorizationIdentifier, email, role, usageTime, remainingTime, signUpFinished);
     }
 }

--- a/src/main/java/com/twentythree/peech/user/domain/UserDomain.java
+++ b/src/main/java/com/twentythree/peech/user/domain/UserDomain.java
@@ -1,10 +1,10 @@
 package com.twentythree.peech.user.domain;
 
-import com.twentythree.peech.user.AuthorizationIdentifier;
-import com.twentythree.peech.user.SignUpFinished;
-import com.twentythree.peech.user.UserGender;
-import com.twentythree.peech.user.UserRole;
-import com.twentythree.peech.user.UserStatus;
+import com.twentythree.peech.user.entity.AuthorizationIdentifier;
+import com.twentythree.peech.user.value.SignUpFinished;
+import com.twentythree.peech.user.value.UserGender;
+import com.twentythree.peech.user.value.UserRole;
+import com.twentythree.peech.user.value.UserStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/twentythree/peech/user/domain/UserDomain.java
+++ b/src/main/java/com/twentythree/peech/user/domain/UserDomain.java
@@ -79,6 +79,22 @@ public class UserDomain {
         return this.deleteAt;
     }
 
+    // Q 1. 이런 식으로 도메인에 수정 코드를 넣고 creator에서 함수를 생성해서 하는게 맞는가, 아니면 이 메소드를 바로 호출하는게 옮은가
+    //  나의 생각으로는 바로 호출하는 게 맞다고 생각이 드는데.. 이유는 모르겠지만 느낌이 뺴야할 것 같은 느낌쓰
+    public void setUser(AuthorizationIdentifier authorizationIdentifier, String firstName, String lastName, LocalDate birth, UserGender gender, String email, String nickName, UserRole role, UserStatus userStatus, SignUpFinished signUpFinished, LocalDate deleteAt) {
+        this.authorizationIdentifier = authorizationIdentifier;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.birth = birth;
+        this.gender = gender;
+        this.email = email;
+        this.nickName = nickName;
+        this.role = role;
+        this.userStatus = userStatus;
+        this.signUpFinished = signUpFinished;
+        this.deleteAt = deleteAt;
+    }
+
     public static UserDomain ofEmail(AuthorizationIdentifier authorizationIdentifier, String email, UserRole role, Long usageTime, Long remainingTime, SignUpFinished signUpFinished){
         return new UserDomain(authorizationIdentifier, email, role, usageTime, remainingTime, signUpFinished);
     }

--- a/src/main/java/com/twentythree/peech/user/domain/UserMapper.java
+++ b/src/main/java/com/twentythree/peech/user/domain/UserMapper.java
@@ -17,7 +17,7 @@ public class UserMapper {
 
     @Transactional
     public Long saveUserDomain(UserDomain userDomain) {
-        UserEntity userEntity = UserEntity.of(userDomain.getUserId(), null, userDomain.getAuthorizationIdentifier(), userDomain.getFirstName(), userDomain.getLastName(), userDomain.getBirth(), userDomain.getGender(), userDomain.getEmail(), userDomain.getNickName());
+        UserEntity userEntity = UserEntity.of(userDomain.getUserId(), null, userDomain.getAuthorizationIdentifier(), userDomain.getFirstName(), userDomain.getLastName(), userDomain.getBirth(), userDomain.getGender(), userDomain.getEmail(), userDomain.getNickName(), userDomain.getSignUpFinished());
 
         UsageTimeEntity usageTimeEntity = UsageTimeEntity.of(userDomain.getUsageTime(), userDomain.getRemainingTime(), userEntity);
 

--- a/src/main/java/com/twentythree/peech/user/dto/request/CompleteProfileRequestDTO.java
+++ b/src/main/java/com/twentythree/peech/user/dto/request/CompleteProfileRequestDTO.java
@@ -1,0 +1,21 @@
+package com.twentythree.peech.user.dto.request;
+
+import com.twentythree.peech.user.value.UserGender;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class CompleteProfileRequestDTO {
+
+    private String firstName;
+    private String lastName;
+
+    private String nickName;
+
+    private LocalDate birth;
+
+    private UserGender gender;
+}

--- a/src/main/java/com/twentythree/peech/user/dto/request/CreateUserRequestDTO.java
+++ b/src/main/java/com/twentythree/peech/user/dto/request/CreateUserRequestDTO.java
@@ -1,9 +1,9 @@
 package com.twentythree.peech.user.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.twentythree.peech.user.AuthorizationServer;
-import com.twentythree.peech.user.UserGender;
-import com.twentythree.peech.user.UserRole;
+import com.twentythree.peech.user.value.AuthorizationServer;
+import com.twentythree.peech.user.value.UserGender;
+import com.twentythree.peech.user.value.UserRole;
 import lombok.Data;
 
 import java.time.LocalDate;

--- a/src/main/java/com/twentythree/peech/user/dto/request/LoginBySocialRequestDTO.java
+++ b/src/main/java/com/twentythree/peech/user/dto/request/LoginBySocialRequestDTO.java
@@ -1,6 +1,6 @@
 package com.twentythree.peech.user.dto.request;
 
-import com.twentythree.peech.user.AuthorizationServer;
+import com.twentythree.peech.user.value.AuthorizationServer;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/twentythree/peech/user/dto/request/LoginBySocialRequestDTO.java
+++ b/src/main/java/com/twentythree/peech/user/dto/request/LoginBySocialRequestDTO.java
@@ -1,0 +1,12 @@
+package com.twentythree.peech.user.dto.request;
+
+import com.twentythree.peech.user.AuthorizationServer;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginBySocialRequestDTO {
+    private String socialToken;
+    private AuthorizationServer authorizationServer;
+}

--- a/src/main/java/com/twentythree/peech/user/dto/response/KakaoGetUserEmailResponseDTO.java
+++ b/src/main/java/com/twentythree/peech/user/dto/response/KakaoGetUserEmailResponseDTO.java
@@ -1,0 +1,10 @@
+package com.twentythree.peech.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class KakaoGetUserEmailResponseDTO {
+    private String email;
+}

--- a/src/main/java/com/twentythree/peech/user/dto/response/KakaoTokenDecodeResponseDTO.java
+++ b/src/main/java/com/twentythree/peech/user/dto/response/KakaoTokenDecodeResponseDTO.java
@@ -1,0 +1,12 @@
+package com.twentythree.peech.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class KakaoTokenDecodeResponseDTO {
+    private Long id;
+    private Integer expires_in;
+    private Integer app_id;
+}

--- a/src/main/java/com/twentythree/peech/user/entity/AuthorizationIdentifier.java
+++ b/src/main/java/com/twentythree/peech/user/entity/AuthorizationIdentifier.java
@@ -1,5 +1,6 @@
-package com.twentythree.peech.user;
+package com.twentythree.peech.user.entity;
 
+import com.twentythree.peech.user.value.AuthorizationServer;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/twentythree/peech/user/entity/UserEntity.java
+++ b/src/main/java/com/twentythree/peech/user/entity/UserEntity.java
@@ -1,7 +1,7 @@
 package com.twentythree.peech.user.entity;
 
 import com.twentythree.peech.common.domain.BaseTimeEntity;
-import com.twentythree.peech.user.*;
+import com.twentythree.peech.user.value.*;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/twentythree/peech/user/entity/UserEntity.java
+++ b/src/main/java/com/twentythree/peech/user/entity/UserEntity.java
@@ -1,10 +1,7 @@
 package com.twentythree.peech.user.entity;
 
 import com.twentythree.peech.common.domain.BaseTimeEntity;
-import com.twentythree.peech.user.AuthorizationIdentifier;
-import com.twentythree.peech.user.UserGender;
-import com.twentythree.peech.user.UserRole;
-import com.twentythree.peech.user.UserStatus;
+import com.twentythree.peech.user.*;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -33,13 +30,13 @@ public class UserEntity extends BaseTimeEntity {
     @Column(name = "device_id", unique=true)
     private String deviceId;
 
-    @Column(name = "first_name", nullable = false)
+    @Column(name = "first_name")
     private String firstName;
 
-    @Column(name = "last_name", nullable = false)
+    @Column(name = "last_name")
     private String lastName;
 
-    @Column(name = "birth", nullable = false)
+    @Column(name = "birth")
     private LocalDate birth;
 
     @Enumerated(EnumType.STRING)
@@ -49,7 +46,7 @@ public class UserEntity extends BaseTimeEntity {
     @Column(name = "email", nullable = false)
     private String email;
 
-    @Column(name = "nick_name", nullable = false)
+    @Column(name = "nick_name")
     private String nickName;
 
     @Enumerated(EnumType.STRING)
@@ -60,6 +57,10 @@ public class UserEntity extends BaseTimeEntity {
     @Column(name = "user_status", nullable = false) @ColumnDefault("'ACTIVE'")
     private UserStatus userStatus;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sign_up_finished", nullable = false)
+    private SignUpFinished signUpFinished;
+
 
     public UserEntity(String device_id) {
         this.deviceId = device_id;
@@ -69,8 +70,8 @@ public class UserEntity extends BaseTimeEntity {
         return new UserEntity(device_id);
     }
 
-    public static UserEntity of(Long id, String deviceId, AuthorizationIdentifier authorizationIdentifier, String firstName, String lastName, LocalDate birth, UserGender gender, String email, String nickName) {
-        return new UserEntity(id, authorizationIdentifier, deviceId, firstName, lastName, birth, gender, email, nickName, UserRole.COMMON, UserStatus.ACTIVE);
+    public static UserEntity of(Long id, String deviceId, AuthorizationIdentifier authorizationIdentifier, String firstName, String lastName, LocalDate birth, UserGender gender, String email, String nickName, SignUpFinished signUpFinished) {
+        return new UserEntity(id, authorizationIdentifier, deviceId, firstName, lastName, birth, gender, email, nickName, UserRole.COMMON, UserStatus.ACTIVE, signUpFinished);
     }
 
     @Override

--- a/src/main/java/com/twentythree/peech/user/repository/UserRepository.java
+++ b/src/main/java/com/twentythree/peech/user/repository/UserRepository.java
@@ -1,5 +1,7 @@
 package com.twentythree.peech.user.repository;
 
+import com.twentythree.peech.user.AuthorizationIdentifier;
+import com.twentythree.peech.user.AuthorizationServer;
 import com.twentythree.peech.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,4 +12,7 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     UserEntity findByDeviceId(String deviceId);
 
     Optional<UserEntity> findByNickName(String nickName);
+
+    @Query("select user from UserEntity user where user.authorizationIdentifier = :authorizationIdentifier")
+    Optional<UserEntity> findByAuthorizationIdentifier(AuthorizationIdentifier authorizationIdentifier);
 }

--- a/src/main/java/com/twentythree/peech/user/repository/UserRepository.java
+++ b/src/main/java/com/twentythree/peech/user/repository/UserRepository.java
@@ -1,7 +1,6 @@
 package com.twentythree.peech.user.repository;
 
-import com.twentythree.peech.user.AuthorizationIdentifier;
-import com.twentythree.peech.user.AuthorizationServer;
+import com.twentythree.peech.user.entity.AuthorizationIdentifier;
 import com.twentythree.peech.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/twentythree/peech/user/service/UserService.java
+++ b/src/main/java/com/twentythree/peech/user/service/UserService.java
@@ -2,9 +2,12 @@ package com.twentythree.peech.user.service;
 
 
 import com.twentythree.peech.common.exception.UserAlreadyExistException;
-import com.twentythree.peech.user.AuthorizationServer;
+import com.twentythree.peech.user.value.AuthorizationServer;
+import com.twentythree.peech.user.value.UserGender;
 import com.twentythree.peech.user.domain.UserDomain;
 import com.twentythree.peech.user.dto.AccessAndRefreshToken;
+
+import java.time.LocalDate;
 
 
 public interface UserService {
@@ -12,4 +15,5 @@ public interface UserService {
     String reIssuanceUserToken(String deviceId);
     UserDomain deleteUser(Long userId);
     AccessAndRefreshToken loginBySocial(String socialToken, AuthorizationServer authorizationServer);
+    AccessAndRefreshToken completeProfile(Long userId, String firstName, String lastName, String nickName, LocalDate birth, UserGender gender);
 }

--- a/src/main/java/com/twentythree/peech/user/service/UserService.java
+++ b/src/main/java/com/twentythree/peech/user/service/UserService.java
@@ -11,5 +11,5 @@ import java.time.LocalDate;
 public interface UserService {
     String createUserByDeviceId(String deviceId) throws UserAlreadyExistException;
     String reIssuanceUserToken(String deviceId);
-    AccessAndRefreshToken createUserBySocial(String socialId, AuthorizationServer authorizationServer, String firstName, String lastName, LocalDate birth, String email, UserGender gender, String nickName);
+    AccessAndRefreshToken loginBySocial(String socialToken, AuthorizationServer authorizationServer);
 }

--- a/src/main/java/com/twentythree/peech/user/service/UserServiceImpl.java
+++ b/src/main/java/com/twentythree/peech/user/service/UserServiceImpl.java
@@ -67,12 +67,14 @@ public class UserServiceImpl implements UserService {
         String accessToken = "";
         String refreshToken = "";
 
+        String bearerSocialToken  = "Bearer " + socialToken;
+
         // Q: 도메인 규칙이라고 볼 수 없는 이런 코드는 위치를 어디로 해야하는가?
         if (authorizationServer == AuthorizationServer.KAKAO) {
-            KakaoTokenDecodeResponseDTO kakaoTokenDecodeResponseDTO = kakaoLoginClient.decodeToken(socialToken);
+            KakaoTokenDecodeResponseDTO kakaoTokenDecodeResponseDTO = kakaoLoginClient.decodeToken(bearerSocialToken);
             socialId = kakaoTokenDecodeResponseDTO.getId().toString();
 
-            KakaoGetUserEmailResponseDTO response = kakaoLoginClient.getUserEmail(socialToken);
+            KakaoGetUserEmailResponseDTO response = kakaoLoginClient.getUserEmail(bearerSocialToken);
             userEmail = response.getEmail();
 
         } else if (authorizationServer == AuthorizationServer.APPLE) {

--- a/src/main/java/com/twentythree/peech/user/service/UserServiceImpl.java
+++ b/src/main/java/com/twentythree/peech/user/service/UserServiceImpl.java
@@ -6,19 +6,23 @@ import com.twentythree.peech.usagetime.domain.UsageTimeEntity;
 import com.twentythree.peech.usagetime.repository.UsageTimeRepository;
 import com.twentythree.peech.user.AuthorizationIdentifier;
 import com.twentythree.peech.user.AuthorizationServer;
-import com.twentythree.peech.user.UserGender;
+import com.twentythree.peech.user.SignUpFinished;
 import com.twentythree.peech.user.UserRole;
+import com.twentythree.peech.user.client.KakaoLoginClient;
 import com.twentythree.peech.user.domain.UserCreator;
 import com.twentythree.peech.user.domain.UserDomain;
 import com.twentythree.peech.user.domain.UserMapper;
 import com.twentythree.peech.user.dto.AccessAndRefreshToken;
+import com.twentythree.peech.user.dto.response.KakaoGetUserEmailResponseDTO;
+import com.twentythree.peech.user.dto.response.KakaoTokenDecodeResponseDTO;
 import com.twentythree.peech.user.entity.UserEntity;
 import com.twentythree.peech.user.repository.UserRepository;
+import com.twentythree.peech.user.validator.UserValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -29,7 +33,11 @@ public class UserServiceImpl implements UserService {
     private final UsageTimeRepository usageTimeRepository;
     private final UserMapper userMapper;
     private final UserCreator userCreator;
+    private final KakaoLoginClient kakaoLoginClient;
+
+    private final UserValidator userValidator;
     private final JWTUtils jwtUtils;
+
 
     @Override
     @Transactional
@@ -52,16 +60,50 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public AccessAndRefreshToken createUserBySocial( String socialId, AuthorizationServer authorizationServer, String firstName, String lastName, LocalDate birth, String email, UserGender gender, String nickName) {
+    public AccessAndRefreshToken loginBySocial( String socialToken, AuthorizationServer authorizationServer) {
+
+        String socialId = "";
+        String userEmail = "";
+
+        String accessToken = "";
+        String refreshToken = "";
+
+        // Q: 도메인 규칙이라고 볼 수 없는 이런 코드는 위치를 어디로 해야하는가?
+        if (authorizationServer == AuthorizationServer.KAKAO) {
+            KakaoTokenDecodeResponseDTO kakaoTokenDecodeResponseDTO = kakaoLoginClient.decodeToken(socialToken);
+            socialId = kakaoTokenDecodeResponseDTO.getId().toString();
+
+            KakaoGetUserEmailResponseDTO response = kakaoLoginClient.getUserEmail(socialToken);
+            userEmail = response.getEmail();
+
+        } else if (authorizationServer == AuthorizationServer.APPLE) {
+            // TODO apple 로그인 구현시 여기서 토큰을 직접 decode
+        } else {
+            throw new IllegalArgumentException(String.format("잘못된 인증 서버입니다: %s", authorizationServer));
+        }
+        // Q
 
         AuthorizationIdentifier authorizationIdentifier = AuthorizationIdentifier.of(socialId, authorizationServer);
 
-        UserDomain userDomain = userCreator.createUser(authorizationIdentifier, firstName, lastName, birth, email, gender, nickName);
-        Long userId = userMapper.saveUserDomain(userDomain);
-        UserRole userRole = userDomain.getRole();
+        if (userValidator.notExistUser(authorizationIdentifier)) {
 
-        String accessToken = jwtUtils.createAccessToken(userId, userRole);
-        String refreshToken = jwtUtils.createRefreshToken(userId, userRole);
+            UserDomain userDomain = userCreator.createUserByEmail(authorizationIdentifier, userEmail, SignUpFinished.PENDING);
+            Long userId = userMapper.saveUserDomain(userDomain);
+            UserRole userRole = userDomain.getRole();
+
+            accessToken = jwtUtils.createAccessToken(userId, userRole);
+            refreshToken = jwtUtils.createRefreshToken(userId, userRole);
+
+        } else if (userValidator.existUser(authorizationIdentifier)) {
+            UserEntity user = userRepository.findByAuthorizationIdentifier(authorizationIdentifier).orElseThrow(() -> new IllegalArgumentException("소셜 로그인이 잘 못되었습니다."));
+            Long userId = user.getId();
+            UserRole userRole = user.getRole();
+
+            accessToken = jwtUtils.createAccessToken(userId, userRole);
+            refreshToken = jwtUtils.createRefreshToken(userId, userRole);
+        } else {
+            throw new RuntimeException("유저 생성에서 예상치 못한 문제가 생겼습니다.");
+        }
 
         return new AccessAndRefreshToken(accessToken, refreshToken);
     }

--- a/src/main/java/com/twentythree/peech/user/validator/UserValidator.java
+++ b/src/main/java/com/twentythree/peech/user/validator/UserValidator.java
@@ -1,6 +1,6 @@
 package com.twentythree.peech.user.validator;
 
-import com.twentythree.peech.user.AuthorizationIdentifier;
+import com.twentythree.peech.user.entity.AuthorizationIdentifier;
 
 public interface UserValidator {
     boolean NickNameIsNotDuplicated(String nickName);

--- a/src/main/java/com/twentythree/peech/user/validator/UserValidator.java
+++ b/src/main/java/com/twentythree/peech/user/validator/UserValidator.java
@@ -1,5 +1,9 @@
 package com.twentythree.peech.user.validator;
 
+import com.twentythree.peech.user.AuthorizationIdentifier;
+
 public interface UserValidator {
     boolean NickNameIsNotDuplicated(String nickName);
+    boolean existUser(AuthorizationIdentifier authorizationIdentifier);
+    boolean notExistUser(AuthorizationIdentifier authorizationIdentifier);
 }

--- a/src/main/java/com/twentythree/peech/user/validator/UserValidatorImpl.java
+++ b/src/main/java/com/twentythree/peech/user/validator/UserValidatorImpl.java
@@ -1,7 +1,6 @@
 package com.twentythree.peech.user.validator;
 
-import com.twentythree.peech.user.AuthorizationIdentifier;
-import com.twentythree.peech.user.AuthorizationServer;
+import com.twentythree.peech.user.entity.AuthorizationIdentifier;
 import com.twentythree.peech.user.entity.UserEntity;
 import com.twentythree.peech.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/twentythree/peech/user/validator/UserValidatorImpl.java
+++ b/src/main/java/com/twentythree/peech/user/validator/UserValidatorImpl.java
@@ -1,5 +1,7 @@
 package com.twentythree.peech.user.validator;
 
+import com.twentythree.peech.user.AuthorizationIdentifier;
+import com.twentythree.peech.user.AuthorizationServer;
 import com.twentythree.peech.user.entity.UserEntity;
 import com.twentythree.peech.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -8,8 +10,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
-@Component
 @RequiredArgsConstructor
+@Component
+@Transactional(readOnly = true)
 public class UserValidatorImpl implements UserValidator {
 
     private final UserRepository userRepository;
@@ -22,4 +25,22 @@ public class UserValidatorImpl implements UserValidator {
 
         return foundNickName.isEmpty();
     }
+
+    @Override
+    public boolean existUser(AuthorizationIdentifier authorizationIdentifier) {
+
+        Optional<UserEntity> user = userRepository.findByAuthorizationIdentifier(authorizationIdentifier);
+
+        if (user.isPresent()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean notExistUser(AuthorizationIdentifier authorizationIdentifier) {
+        return !existUser(authorizationIdentifier);
+    }
+
 }

--- a/src/main/java/com/twentythree/peech/user/value/AuthorizationServer.java
+++ b/src/main/java/com/twentythree/peech/user/value/AuthorizationServer.java
@@ -1,4 +1,4 @@
-package com.twentythree.peech.user;
+package com.twentythree.peech.user.value;
 
 public enum AuthorizationServer {
     KAKAO, APPLE

--- a/src/main/java/com/twentythree/peech/user/value/SignUpFinished.java
+++ b/src/main/java/com/twentythree/peech/user/value/SignUpFinished.java
@@ -1,4 +1,4 @@
-package com.twentythree.peech.user;
+package com.twentythree.peech.user.value;
 
 public enum SignUpFinished {
     PENDING, FINISHED

--- a/src/main/java/com/twentythree/peech/user/value/UserGender.java
+++ b/src/main/java/com/twentythree/peech/user/value/UserGender.java
@@ -1,4 +1,4 @@
-package com.twentythree.peech.user;
+package com.twentythree.peech.user.value;
 
 public enum UserGender {
     MALE, FEMALE

--- a/src/main/java/com/twentythree/peech/user/value/UserRole.java
+++ b/src/main/java/com/twentythree/peech/user/value/UserRole.java
@@ -1,4 +1,4 @@
-package com.twentythree.peech.user;
+package com.twentythree.peech.user.value;
 
 public enum UserRole {
     ROLE_COMMON, ROLE_ADMIN

--- a/src/main/java/com/twentythree/peech/user/value/UserStatus.java
+++ b/src/main/java/com/twentythree/peech/user/value/UserStatus.java
@@ -1,4 +1,4 @@
-package com.twentythree.peech.user;
+package com.twentythree.peech.user.value;
 
 public enum UserStatus {
     ACTIVE, DELETE

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,5 +1,5 @@
-INSERT INTO user (birth, created_at, updated_at, social_id, user_id, device_id, email, first_name, last_name, nick_name, authorization_server, gender, role, user_status) VALUES
-    ('2018-02-01', '2018-02-01', '2018-12-18', '124123123', '1', 'device_1', 'asdf@naver.com', 'ex', 'ample', 'nick', 'KAKAO', 'MALE', 'COMMON', 'ACTIVE');
+INSERT INTO user (birth, created_at, updated_at, social_id, user_id, device_id, email, first_name, last_name, nick_name, authorization_server, gender, role, user_status, sign_up_finished) VALUES
+    ('2018-02-01', '2018-02-01', '2018-12-18', '124123123', '1', 'device_1', 'asdf@naver.com', 'ex', 'ample', 'nick', 'KAKAO', 'MALE', 'COMMON', 'ACTIVE', 'PENDING');
 
 INSERT INTO usage_time(usage_time_id, user_id, created_at, updated_at, remaining_time) VALUES
     (1, 1, '2018-02-01', '2018-12-18', '9000');


### PR DESCRIPTION
spring application에 바로 설정을 등록하지 않고 OpenFeignConfig에 설정을 등록
accesstoken, refreshtoken 만료시간 설정 at 30일 rt 60일

존재하는 유저인지 판단하는 validator 생성, 소셜로그인 정보로 존재하는 유저인지 판단, 존재하지 않는 유저인지 판단.

openFeign을 이용하여 카카오에 유저 토큰을 해독유저 정보를 조회하는 클라이언트를 생성

sign_up_finished 컬럼 생성 초기에 카카오에서 주는 정보로만 생성하는 authorizationIdentifier, email, role, userStatus, signupfinished만 not null
domain entity에 signUpFinished 추가

유저가 준 소셜 토큰으로 유저 id와 인증 서버를 가지고 authorizationIdentifier를 생성 소셜 토큰을 통해 email을 조회

authorizationIdentifier를 이용해 소셜 로그인을 진행한적이 있는 유저인지 조회 로그인을 진행한적이 없다면 새로운 유저를 생성하고 토큰을 발급

소셜토큰과 토큰 발급처를 통해 최초 유저를 생하고 sign up finished를 false로 했다는 것을 클라이언트에 알려주기 위해서 http status code를 411로 응답

