### PR TITLE
TT-349 apple sign in

### DIFF
--- a/src/main/java/com/twentythree/peech/common/exception/BaseException.java
+++ b/src/main/java/com/twentythree/peech/common/exception/BaseException.java
@@ -2,7 +2,6 @@ package com.twentythree.peech.common.exception;
 
 import com.twentythree.peech.common.dto.UserAlreadyExistErrorVO;
 import com.twentythree.peech.common.dto.ErrorDTO;
-import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -20,6 +19,13 @@ public class BaseException {
         log.error("이미 가입된 유저 에러 발생", e);
         UserAlreadyExistErrorVO alreadyExistErrorVO = new UserAlreadyExistErrorVO(e.getMessage());
         return new ResponseEntity<>(alreadyExistErrorVO, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(Unauthorized.class)
+    public ResponseEntity<Unauthorized> unauthorizedExceptionHandler(Unauthorized e) {
+        log.error(e.getMessage(), e);
+        Unauthorized unauthorized = new Unauthorized(e.getMessage());
+        return new ResponseEntity<>(unauthorized, HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/twentythree/peech/common/exception/Unauthorized.java
+++ b/src/main/java/com/twentythree/peech/common/exception/Unauthorized.java
@@ -1,0 +1,5 @@
+package com.twentythree.peech.common.exception;
+
+public class Unauthorized extends RuntimeException{
+    public Unauthorized(String message) { super(message); }
+}

--- a/src/main/java/com/twentythree/peech/common/utils/JWTUtils.java
+++ b/src/main/java/com/twentythree/peech/common/utils/JWTUtils.java
@@ -1,6 +1,10 @@
 package com.twentythree.peech.common.utils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twentythree.peech.common.JwtProperties;
+import com.twentythree.peech.user.dto.IdentityToken;
+import com.twentythree.peech.user.dto.IdentityTokenHeader;
+import com.twentythree.peech.user.dto.IdentityTokenPayload;
 import com.twentythree.peech.user.value.UserRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
@@ -102,7 +106,7 @@ public class JWTUtils {
         return claimsJws;
     }
 
-    public Jws<Claims> parseAccessToken(String token, Long userId) {
+    public Jws<Claims> parseAccessToken(String token) {
         Jws<Claims> claimsJws = Jwts.parser()
                 .verifyWith(accessKey)
                 .build()
@@ -111,13 +115,37 @@ public class JWTUtils {
         return claimsJws;
     }
 
-    public Jws<Claims> parseRefreshToken(String token, Long userId) {
+    public Jws<Claims> parseRefreshToken(String token) {
         Jws<Claims> claimsJws = Jwts.parser()
                 .verifyWith(refreshKey)
                 .build()
                 .parseSignedClaims(token);
 
         return claimsJws;
+    }
+
+    public IdentityToken decodeIdentityToken(String token) {
+        try {
+
+            String[] splitToken = token.split("\\.");
+
+            String header = splitToken[0];
+            String payload = splitToken[1];
+
+            String tokenHeader = new String(Decoders.BASE64.decode(header));
+            String tokenPayload = new String(Decoders.BASE64.decode(payload));
+
+
+            ObjectMapper objectMapper = new ObjectMapper();
+
+            IdentityTokenHeader identityTokenHeader = objectMapper.readValue(tokenHeader, IdentityTokenHeader.class);
+            IdentityTokenPayload identityTokenPayload = objectMapper.readValue(tokenPayload, IdentityTokenPayload.class);
+
+
+            return new IdentityToken(identityTokenHeader, identityTokenPayload);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("error", e);
+        }
     }
 
 }

--- a/src/main/java/com/twentythree/peech/user/client/AppleLoginClient.java
+++ b/src/main/java/com/twentythree/peech/user/client/AppleLoginClient.java
@@ -1,0 +1,12 @@
+package com.twentythree.peech.user.client;
+
+import com.twentythree.peech.user.dto.response.ApplePublicKeyResponseDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "AppleLoginClient", url = "https://appleid.apple.com/auth/oauth2/")
+public interface AppleLoginClient {
+
+    @GetMapping("v2/keys")
+    ApplePublicKeyResponseDTO getPublicKeys();
+}

--- a/src/main/java/com/twentythree/peech/user/dto/ApplePublicKey.java
+++ b/src/main/java/com/twentythree/peech/user/dto/ApplePublicKey.java
@@ -1,0 +1,15 @@
+package com.twentythree.peech.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApplePublicKey {
+    private String alg;
+    private String e;
+    private String kid;
+    private String kty;
+    private String n;
+    private String use;
+}

--- a/src/main/java/com/twentythree/peech/user/dto/IdentityToken.java
+++ b/src/main/java/com/twentythree/peech/user/dto/IdentityToken.java
@@ -1,0 +1,44 @@
+package com.twentythree.peech.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+import java.util.Objects;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class IdentityToken {
+
+    private IdentityTokenHeader identityTokenHeader;
+    private IdentityTokenPayload identityTokenPayload;
+
+    public boolean isVerify(List<ApplePublicKey> publicKeys) {
+        String alg = identityTokenHeader.getAlg();
+        String kid = identityTokenHeader.getKid();
+
+        for (ApplePublicKey publicKey : publicKeys) {
+            if (publicKey.getKid().equals(alg) && publicKey.getAlg().equals(kid)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        IdentityToken that = (IdentityToken) o;
+        return Objects.equals(identityTokenHeader, that.identityTokenHeader) && Objects.equals(identityTokenPayload, that.identityTokenPayload);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identityTokenHeader, identityTokenPayload);
+    }
+}

--- a/src/main/java/com/twentythree/peech/user/dto/IdentityTokenHeader.java
+++ b/src/main/java/com/twentythree/peech/user/dto/IdentityTokenHeader.java
@@ -1,0 +1,31 @@
+package com.twentythree.peech.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.Objects;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class IdentityTokenHeader {
+
+    private String alg;
+    private String kid;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        IdentityTokenHeader that = (IdentityTokenHeader) o;
+        return Objects.equals(alg, that.alg) && Objects.equals(kid, that.kid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(alg, kid);
+    }
+}

--- a/src/main/java/com/twentythree/peech/user/dto/IdentityTokenPayload.java
+++ b/src/main/java/com/twentythree/peech/user/dto/IdentityTokenPayload.java
@@ -1,0 +1,34 @@
+package com.twentythree.peech.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.Objects;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class IdentityTokenPayload {
+     private String iss;
+     private Long iat;
+     private Long exp;
+     private String aud;
+     private String sub;
+     private String email;
+
+     @Override
+     public boolean equals(Object o) {
+          if (this == o) return true;
+          if (o == null || getClass() != o.getClass()) return false;
+          IdentityTokenPayload that = (IdentityTokenPayload) o;
+          return Objects.equals(iss, that.iss) && Objects.equals(iat, that.iat) && Objects.equals(exp, that.exp) && Objects.equals(aud, that.aud) && Objects.equals(sub, that.sub) && Objects.equals(email, that.email);
+     }
+
+     @Override
+     public int hashCode() {
+          return Objects.hash(iss, iat, exp, aud, sub, email);
+     }
+}

--- a/src/main/java/com/twentythree/peech/user/dto/response/ApplePublicKeyResponseDTO.java
+++ b/src/main/java/com/twentythree/peech/user/dto/response/ApplePublicKeyResponseDTO.java
@@ -1,0 +1,13 @@
+package com.twentythree.peech.user.dto.response;
+
+import com.twentythree.peech.user.dto.ApplePublicKey;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ApplePublicKeyResponseDTO {
+    private List<ApplePublicKey> applePublicKeys;
+}

--- a/src/test/java/com/twentythree/peech/common/utils/JWTUtilsTest.java
+++ b/src/test/java/com/twentythree/peech/common/utils/JWTUtilsTest.java
@@ -1,0 +1,36 @@
+package com.twentythree.peech.common.utils;
+
+import com.twentythree.peech.user.dto.IdentityToken;
+import com.twentythree.peech.user.dto.IdentityTokenHeader;
+import com.twentythree.peech.user.dto.IdentityTokenPayload;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class JWTUtilsTest {
+
+    @Autowired private JWTUtils jwtUtils;
+
+    @Test
+    public void decodeJwt() throws Exception {
+        //Given
+
+        String jwt = "eyJhbGciOiJFUzI1NiIsImtpZCI6InF3ZSJ9.eyJzdWIiOiJjb20ubXl0ZXN0LmFwcCIsImlzcyI6IkRFRjEyM0dISUoiLCJpYXQiOjE0MzcxNzkwMzYsImV4cCI6MTIzMTIzMTIzLCJhdWQiOiJodHRwczovL2FwcGxlaWQuYXBwbGUuY29tIiwiZW1haWwiOiJxd2UifQ.u8y5Ujn3mYebx7xZ_SwyTqgPEQ9idLuDX8LWr3r1hbL36eOzthXS-EUmDxEaJDPR4TNn045SMdqMcjfAU7x29w";
+
+        //When
+
+        IdentityToken identityToken = jwtUtils.decodeIdentityToken(jwt);
+
+        //Then
+
+        IdentityTokenHeader identityTokenHeader = new IdentityTokenHeader("ES256", "qwe");
+        IdentityTokenPayload identityTokenPayload = new IdentityTokenPayload("DEF123GHIJ", 1437179036L, 123123123L, "https://appleid.apple.com", "com.mytest.app", "qwe");
+        IdentityToken resultIdentityToken = new IdentityToken(identityTokenHeader, identityTokenPayload);
+
+        Assertions.assertThat(identityToken).isEqualTo(resultIdentityToken);
+
+    }
+
+}


### PR DESCRIPTION
애플의 identity 토큰을 해독하고 헤더와 페이로드를 저장
identity token을 검증하기 위해 애플에서 키값을 받아온다.
클라이언트에서 주는 토큰을 애플에서 키값을 받아 검증
애플 키값을 분해하여 이메일을 가져온다

401에러가 클라이언트에게 가면 로그인 화면을 띄워주게 된다.
Unauthorized라는 커스텀 에러를 만들고 401을 응답하게 한다.

