### PR TITLE
bug: filter 적용시 health 체크 안되는 문제

### DIFF
--- a/src/main/java/com/twentythree/peech/security/config/SecurityConfig.java
+++ b/src/main/java/com/twentythree/peech/security/config/SecurityConfig.java
@@ -40,9 +40,8 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize ->
-                        authorize.requestMatchers("/api/v1.1/auth/reissue").permitAll()
+                        authorize.requestMatchers("/api/v1.1/auth/reissue","/actuator").permitAll()
                                 .requestMatchers(HttpMethod.POST,"/api/v1.1/user").permitAll()
-                                .requestMatchers("/swagger-ui/").hasAuthority("ROLE_ADMIN")
                                 .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, ExceptionTranslationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
- dev환경 dev.peech.co.kr 연결시 target group health check가 안되는 문제 발생
- filter가 적용되어서 해당 uri를 401에러 처리하는 것을 확인
- /actuator uri시 필터 인증로직 하지 않도록 변경