### PR TITLE
TT-376 @LoginUserId를 SecurityContextHolder로 변경

### DIFF
--- a/src/main/java/com/twentythree/peech/auth/config/ArgumentResolverConfig.java
+++ b/src/main/java/com/twentythree/peech/auth/config/ArgumentResolverConfig.java
@@ -9,6 +9,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
 
+@Deprecated
 @RequiredArgsConstructor
 @Configuration
 public class ArgumentResolverConfig implements WebMvcConfigurer {

--- a/src/main/java/com/twentythree/peech/auth/dto/LoginUserId.java
+++ b/src/main/java/com/twentythree/peech/auth/dto/LoginUserId.java
@@ -7,5 +7,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Deprecated
 public @interface LoginUserId {
 }

--- a/src/main/java/com/twentythree/peech/auth/dto/UserIdDTO.java
+++ b/src/main/java/com/twentythree/peech/auth/dto/UserIdDTO.java
@@ -1,5 +1,5 @@
 package com.twentythree.peech.auth.dto;
 
-
+@Deprecated
 public record UserIdDTO(Long userId) {
 }

--- a/src/main/java/com/twentythree/peech/auth/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/twentythree/peech/auth/interceptor/AuthInterceptor.java
@@ -1,14 +1,13 @@
 package com.twentythree.peech.auth.interceptor;
 
-import com.twentythree.peech.common.exception.UserAlreadyExistException;
 import com.twentythree.peech.common.utils.JWTUtils;
-import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
+@Deprecated
 @RequiredArgsConstructor
 public class AuthInterceptor implements HandlerInterceptor {
 

--- a/src/main/java/com/twentythree/peech/auth/resolver/AuthArgumentResolver.java
+++ b/src/main/java/com/twentythree/peech/auth/resolver/AuthArgumentResolver.java
@@ -14,6 +14,7 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+@Deprecated
 @Slf4j
 @RequiredArgsConstructor
 public class AuthArgumentResolver implements HandlerMethodArgumentResolver {

--- a/src/main/java/com/twentythree/peech/auth/service/SecurityContextHolder.java
+++ b/src/main/java/com/twentythree/peech/auth/service/SecurityContextHolder.java
@@ -1,0 +1,14 @@
+package com.twentythree.peech.auth.service;
+
+import com.twentythree.peech.security.jwt.JWTAuthentication;
+import org.springframework.security.core.Authentication;
+
+public class SecurityContextHolder {
+
+    public static Long getUserId() {
+        Authentication authentication = org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication();
+        JWTAuthentication jwtAuthentication = (JWTAuthentication) authentication.getPrincipal();
+
+        return jwtAuthentication.getUserId();
+    }
+}

--- a/src/main/java/com/twentythree/peech/common/interceptor/RequestLogInterceptor.java
+++ b/src/main/java/com/twentythree/peech/common/interceptor/RequestLogInterceptor.java
@@ -1,5 +1,6 @@
 package com.twentythree.peech.common.interceptor;
 
+import com.twentythree.peech.auth.service.SecurityContextHolder;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
@@ -15,7 +16,7 @@ public class RequestLogInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         Logger logger = LoggerFactory.getLogger(this.getClass().getSimpleName());
 
-        Long userId = (Long) request.getAttribute("userId");
+        Long userId = SecurityContextHolder.getUserId();
         String requestURI = request.getRequestURI();
         String uuid = UUID.randomUUID().toString();
 

--- a/src/main/java/com/twentythree/peech/script/controller/ScriptController.java
+++ b/src/main/java/com/twentythree/peech/script/controller/ScriptController.java
@@ -1,7 +1,7 @@
 package com.twentythree.peech.script.controller;
 
-import com.twentythree.peech.auth.dto.LoginUserId;
 import com.twentythree.peech.auth.dto.UserIdDTO;
+import com.twentythree.peech.auth.service.SecurityContextHolder;
 import com.twentythree.peech.script.dto.request.ModifiedScriptRequestDTO;
 import com.twentythree.peech.script.dto.request.ParagraphsRequestDTO;
 import com.twentythree.peech.script.dto.response.*;
@@ -10,7 +10,9 @@ import com.twentythree.peech.script.service.ScriptSentenceFacade;
 import com.twentythree.peech.script.service.ScriptService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.AllArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+
 
 @RestController
 @AllArgsConstructor
@@ -69,14 +71,17 @@ public class ScriptController implements SwaggerScriptInterface{
             description = "수정한 측정대본을 전달하면 수정된 부분에 대해서는 예상 시간을 통해서 결과를 응답한다.")
     @Override
     @PostMapping("/api/v1/themes/{themeId}/scripts/{scriptId}")
-    public ModifyScriptResponseDTO modifyScript(@PathVariable Long themeId, @PathVariable Long scriptId, @RequestBody ModifiedScriptRequestDTO request, @LoginUserId UserIdDTO userId) {
-        return scriptService.modifyScriptService(request.getParagraphs(), scriptId, userId.userId());
+    public ModifyScriptResponseDTO modifyScript(@PathVariable Long themeId, @PathVariable Long scriptId, @RequestBody ModifiedScriptRequestDTO request) {
+        Long userId = SecurityContextHolder.getUserId();
+
+        return scriptService.modifyScriptService(request.getParagraphs(), scriptId, userId);
     }
 
     @Override
     @PutMapping("api/v1/themes/{themeId}/scripts/{scriptId}")
-    public SaveScriptAndSentencesResponseDTO saveModifyScript(@PathVariable Long themeId,@PathVariable Long scriptId,@LoginUserId UserIdDTO userId) {
-        return saveModifyScriptService.saveModifyScript(themeId, scriptId, userId.userId());
+    public SaveScriptAndSentencesResponseDTO saveModifyScript(@PathVariable Long themeId,@PathVariable Long scriptId) {
+        Long userId = SecurityContextHolder.getUserId();
+        return saveModifyScriptService.saveModifyScript(themeId, scriptId, userId);
     }
 
     @Operation(summary = "")

--- a/src/main/java/com/twentythree/peech/script/controller/SwaggerScriptInterface.java
+++ b/src/main/java/com/twentythree/peech/script/controller/SwaggerScriptInterface.java
@@ -1,17 +1,12 @@
 package com.twentythree.peech.script.controller;
 
-import com.twentythree.peech.auth.dto.LoginUserId;
-import com.twentythree.peech.auth.dto.UserIdDTO;
 import com.twentythree.peech.script.dto.MinorScriptDTO;
 import com.twentythree.peech.script.dto.request.ModifiedScriptRequestDTO;
 import com.twentythree.peech.script.dto.request.ParagraphsRequestDTO;
 import com.twentythree.peech.script.dto.response.*;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import lombok.extern.java.Log;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -38,10 +33,10 @@ public interface SwaggerScriptInterface {
     MinorDetailScriptDTO getMinorScriptDetail(@PathVariable Long themeId, @PathVariable Long majorVersion, @PathVariable Long minorVersion);
 
     @ApiResponse(responseCode = "200", description = "success", content = {@Content(schema = @Schema(implementation = ModifyScriptResponseDTO.class), mediaType = "application/json")})
-    ModifyScriptResponseDTO modifyScript(@PathVariable Long themeId, @PathVariable Long scriptId, @RequestBody ModifiedScriptRequestDTO request, @LoginUserId UserIdDTO userId);
+    ModifyScriptResponseDTO modifyScript(@PathVariable Long themeId, @PathVariable Long scriptId, @RequestBody ModifiedScriptRequestDTO request);
 
     @ApiResponse(responseCode = "200", description = "success", content = {@Content(schema = @Schema(implementation = SaveScriptAndSentencesResponseDTO.class), mediaType = "application/json")})
-    SaveScriptAndSentencesResponseDTO saveModifyScript(@PathVariable Long themeId, @PathVariable Long scriptId, @Parameter(hidden = true) @LoginUserId UserIdDTO userId);
+    SaveScriptAndSentencesResponseDTO saveModifyScript(@PathVariable Long themeId, @PathVariable Long scriptId);
 
     @ApiResponse(responseCode = "200", description = "success", content = {@Content(schema = @Schema(implementation = ParagraphsResponseDTO.class), mediaType = "application/json")})
     @GetMapping("api/v1/themes/{themeId}/scripts/{scriptId}/paragraphs")

--- a/src/main/java/com/twentythree/peech/script/controller/SwaggerThemeInterface.java
+++ b/src/main/java/com/twentythree/peech/script/controller/SwaggerThemeInterface.java
@@ -1,7 +1,5 @@
 package com.twentythree.peech.script.controller;
 
-import com.twentythree.peech.auth.dto.LoginUserId;
-import com.twentythree.peech.auth.dto.UserIdDTO;
 import com.twentythree.peech.script.dto.request.ThemeTitleRequestDTO;
 import com.twentythree.peech.script.dto.response.ThemeIdResponseDTO;
 import com.twentythree.peech.script.dto.response.ThemesResponseDTO;
@@ -13,8 +11,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface SwaggerThemeInterface {
 
     @ApiResponse(responseCode = "201", description = "성공", content = {@Content(schema = @Schema(implementation = ThemeIdResponseDTO.class), mediaType = "application/json")})
-    ThemeIdResponseDTO saveTheme(@RequestBody ThemeTitleRequestDTO request, @LoginUserId UserIdDTO userIdDTO);
+    ThemeIdResponseDTO saveTheme(@RequestBody ThemeTitleRequestDTO request);
 
     @ApiResponse(responseCode = "200", description = "success")
-    ThemesResponseDTO getThemes(@LoginUserId UserIdDTO userIdDTO);
+    ThemesResponseDTO getThemes();
 }

--- a/src/main/java/com/twentythree/peech/script/controller/ThemeController.java
+++ b/src/main/java/com/twentythree/peech/script/controller/ThemeController.java
@@ -1,7 +1,6 @@
 package com.twentythree.peech.script.controller;
 
-import com.twentythree.peech.auth.dto.LoginUserId;
-import com.twentythree.peech.auth.dto.UserIdDTO;
+import com.twentythree.peech.auth.service.SecurityContextHolder;
 import com.twentythree.peech.script.dto.request.ThemeTitleRequestDTO;
 import com.twentythree.peech.script.dto.response.ThemeIdResponseDTO;
 import com.twentythree.peech.script.dto.response.ThemesResponseDTO;
@@ -23,8 +22,8 @@ public class ThemeController implements SwaggerThemeInterface {
     @Operation(summary = "주제 저장", description = "사용자가 주제를 생성할 때 호출")
     @Override
     @PostMapping("/api/v1/theme")
-    public ThemeIdResponseDTO saveTheme(@RequestBody ThemeTitleRequestDTO request, @LoginUserId UserIdDTO userIdDTO) {
-        Long userId = userIdDTO.userId();
+    public ThemeIdResponseDTO saveTheme(@RequestBody ThemeTitleRequestDTO request) {
+        Long userId = SecurityContextHolder.getUserId();
 
         Long themeId = themeService.saveTheme(userId, request.themeTitle());
 
@@ -33,8 +32,8 @@ public class ThemeController implements SwaggerThemeInterface {
 
     @Override
     @GetMapping("/api/v1/themes")
-    public ThemesResponseDTO getThemes(@LoginUserId UserIdDTO userIdDTO) {
-        Long userId = userIdDTO.userId();
+    public ThemesResponseDTO getThemes() {
+        Long userId = SecurityContextHolder.getUserId();
 
         return themeService.getThemesByUserId(userId);
     }

--- a/src/main/java/com/twentythree/peech/script/stt/controller/STTController.java
+++ b/src/main/java/com/twentythree/peech/script/stt/controller/STTController.java
@@ -1,7 +1,6 @@
 package com.twentythree.peech.script.stt.controller;
 
-import com.twentythree.peech.auth.dto.LoginUserId;
-import com.twentythree.peech.auth.dto.UserIdDTO;
+import com.twentythree.peech.auth.service.SecurityContextHolder;
 import com.twentythree.peech.script.stt.dto.request.STTRequestDto;
 import com.twentythree.peech.script.stt.dto.response.STTScriptResponseDTO;
 import com.twentythree.peech.script.stt.service.ProcessSTTService;
@@ -21,8 +20,10 @@ public class STTController implements SwaggerSTTController{
         description = "대본 입력없이 바로 음성녹음을 STTRequestDTO에 담아 요청하면 Processing과정을 거쳐 STTResultResponseDTO에 담아 응답한다.")
     @PostMapping(value ="/api/v1/themes/{themeId}/scripts/speech/script", consumes = "multipart/form-data")
     @Override
-    public Mono<STTScriptResponseDTO> responseSTTResult(@ModelAttribute STTRequestDto request, @PathVariable("themeId") Long themeId, @LoginUserId UserIdDTO userId){
-        return processSTTService.createSTTResult(request, themeId, userId.userId());
+    public Mono<STTScriptResponseDTO> responseSTTResult(@ModelAttribute STTRequestDto request, @PathVariable("themeId") Long themeId){
+        Long userId = SecurityContextHolder.getUserId();
+
+        return processSTTService.createSTTResult(request, themeId, userId);
     }
 
 
@@ -30,7 +31,9 @@ public class STTController implements SwaggerSTTController{
             description = "대본이 입력된 상태에서 음성녹음을 STTRequestDTO에 담아 요청하면 Processing과정을 거쳐 STTResultResponseDTO에 담아 응답한다.")
     @PostMapping(value ="/api/v1/themes/{themeId}/scripts/{scriptId}/speech/script", consumes = "multipart/form-data")
     @Override
-    public Mono<STTScriptResponseDTO> responseSTTResult(@ModelAttribute STTRequestDto request, @PathVariable("themeId") Long themeId, @PathVariable("scriptId") Long scriptId, @LoginUserId UserIdDTO userId){
-        return processSTTService.createSTTResult(request, themeId, scriptId, userId.userId());
+    public Mono<STTScriptResponseDTO> responseSTTResult(@ModelAttribute STTRequestDto request, @PathVariable("themeId") Long themeId, @PathVariable("scriptId") Long scriptId){
+        Long userId = SecurityContextHolder.getUserId();
+
+        return processSTTService.createSTTResult(request, themeId, scriptId, userId);
     }
 }

--- a/src/main/java/com/twentythree/peech/script/stt/controller/SwaggerSTTController.java
+++ b/src/main/java/com/twentythree/peech/script/stt/controller/SwaggerSTTController.java
@@ -1,10 +1,7 @@
 package com.twentythree.peech.script.stt.controller;
 
-import com.twentythree.peech.auth.dto.LoginUserId;
-import com.twentythree.peech.auth.dto.UserIdDTO;
 import com.twentythree.peech.script.stt.dto.request.STTRequestDto;
 import com.twentythree.peech.script.stt.dto.response.STTScriptResponseDTO;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -15,9 +12,9 @@ import reactor.core.publisher.Mono;
 public interface SwaggerSTTController {
     @ApiResponse(responseCode = "201" , description = "성공", content = {@Content(schema = @Schema(implementation = STTScriptResponseDTO.class), mediaType = "application/json")})
     @ApiResponse(responseCode = "400" , description = "실패", content = {@Content(schema = @Schema(implementation = Error.class), mediaType = "application/json")})
-    Mono<STTScriptResponseDTO>  responseSTTResult(@ModelAttribute STTRequestDto request, @PathVariable("themeId") Long themeId, @PathVariable("scriptId") Long scriptId, @Parameter(hidden = true) @LoginUserId UserIdDTO userId);
+    Mono<STTScriptResponseDTO>  responseSTTResult(@ModelAttribute STTRequestDto request, @PathVariable("themeId") Long themeId, @PathVariable("scriptId") Long scriptId);
 
     @ApiResponse(responseCode = "201" , description = "성공", content = {@Content(schema = @Schema(implementation = STTScriptResponseDTO.class), mediaType = "application/json")})
     @ApiResponse(responseCode = "400" , description = "실패", content = {@Content(schema = @Schema(implementation = Error.class), mediaType = "application/json")})
-    Mono<STTScriptResponseDTO>  responseSTTResult(@ModelAttribute STTRequestDto request, @PathVariable("themeId") Long themeId, @Parameter(hidden = true) @LoginUserId UserIdDTO userId);
+    Mono<STTScriptResponseDTO>  responseSTTResult(@ModelAttribute STTRequestDto request, @PathVariable("themeId") Long themeId);
 }

--- a/src/main/java/com/twentythree/peech/usagetime/controller/SwaggerUsageTimeController.java
+++ b/src/main/java/com/twentythree/peech/usagetime/controller/SwaggerUsageTimeController.java
@@ -1,7 +1,5 @@
 package com.twentythree.peech.usagetime.controller;
 
-import com.twentythree.peech.auth.dto.LoginUserId;
-import com.twentythree.peech.auth.dto.UserIdDTO;
 import com.twentythree.peech.usagetime.dto.response.CheckRemainingTimeResponseDTO;
 import com.twentythree.peech.usagetime.dto.response.TextAndSecondResponseDTO;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,10 +8,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface SwaggerUsageTimeController {
 
     @GetMapping("api/v1/usage-time")
-    CheckRemainingTimeResponseDTO checkRemainingTime(@LoginUserId UserIdDTO userId, @RequestParam(name = "audio-time") Long audioTime);
+    CheckRemainingTimeResponseDTO checkRemainingTime(@RequestParam(name = "audio-time") Long audioTime);
 
     @GetMapping("api/v1/usage-time")
-    TextAndSecondResponseDTO getUsageTime(@LoginUserId UserIdDTO userId);
+    TextAndSecondResponseDTO getUsageTime();
 
     @GetMapping("api/v1/max-audio-time")
     TextAndSecondResponseDTO getMaxAudioTime();

--- a/src/main/java/com/twentythree/peech/usagetime/controller/UsageTimeController.java
+++ b/src/main/java/com/twentythree/peech/usagetime/controller/UsageTimeController.java
@@ -1,6 +1,6 @@
 package com.twentythree.peech.usagetime.controller;
 
-import com.twentythree.peech.auth.dto.UserIdDTO;
+import com.twentythree.peech.auth.service.SecurityContextHolder;
 import com.twentythree.peech.usagetime.dto.response.CheckRemainingTimeResponseDTO;
 import com.twentythree.peech.usagetime.dto.response.TextAndSecondResponseDTO;
 import com.twentythree.peech.usagetime.service.UsageTimeService;
@@ -17,14 +17,18 @@ public class UsageTimeController implements SwaggerUsageTimeController{
 
     @Override
     @GetMapping("api/v1/usage-time")
-    public CheckRemainingTimeResponseDTO checkRemainingTime(UserIdDTO userId, Long audioTime) {
-        return usageTimeService.checkRemainingTime(userId.userId(), audioTime);
+    public CheckRemainingTimeResponseDTO checkRemainingTime(Long audioTime) {
+        Long userId = SecurityContextHolder.getUserId();
+
+        return usageTimeService.checkRemainingTime(userId, audioTime);
     }
 
     @Override
     @GetMapping("api/v1/remaining-time")
-    public TextAndSecondResponseDTO getUsageTime(UserIdDTO userId) {
-        return usageTimeService.getUsageTime(userId.userId());
+    public TextAndSecondResponseDTO getUsageTime() {
+        Long userId = SecurityContextHolder.getUserId();
+
+        return usageTimeService.getUsageTime(userId);
     }
 
     @Override


### PR DESCRIPTION
security context hodler에서 user id를 가져오는 함수를 static 으로 만들어 사용
argument resolver에서 user id를 가져오는 것들을 security context holder에서 가져오는 것으로 모두 변경
arguement resolver를 써 userId를 가져오는 것들을 deprecated 시킴
