### PR TITLE
TT-387 access, refresh token expiredTime 초기화

### DIFF
--- a/src/main/java/com/twentythree/peech/common/utils/JWTUtils.java
+++ b/src/main/java/com/twentythree/peech/common/utils/JWTUtils.java
@@ -57,10 +57,14 @@ public class JWTUtils {
 
         this.refreshKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(refreshString));
 
+    }
+
+    private void setExpirationDate() {
         Date today = new Date();
         this.accessExpirationDate = new Date(today.getTime() + (1000 * accessExpiration));
         this.refreshExpirationDate = new Date(today.getTime() + (1000 * refreshExpiration));
     }
+
 
 
     public String createJWT(Long userId) {
@@ -74,6 +78,8 @@ public class JWTUtils {
     }
 
     public String createAccessToken(Long userId, UserRole userRole) {
+        setExpirationDate();
+
         return Jwts.builder().
                 header().type("JWT").
                 and().
@@ -86,6 +92,8 @@ public class JWTUtils {
     }
 
     public String createRefreshToken(Long userId, UserRole userRole) {
+        setExpirationDate();
+
         return Jwts.builder().
                 header().type("JWT").
                 and().

--- a/src/main/java/com/twentythree/peech/user/controller/UserController.java
+++ b/src/main/java/com/twentythree/peech/user/controller/UserController.java
@@ -55,6 +55,7 @@ public class UserController implements SwaggerUserController{
 
         LoginBySocial loginBySocial = userService.loginBySocial(token, authorizationServer);
         UserIdTokenResponseDTO userIdTokenResponseDTO = new UserIdTokenResponseDTO(loginBySocial.getAccessToken(), loginBySocial.getRefreshToken());
+        log.info("{}", userIdTokenResponseDTO.getAccessToken());
         return ResponseEntity.status(201).body(new WrappedResponseBody<UserIdTokenResponseDTO>(loginBySocial.getResponseCode(), userIdTokenResponseDTO));
     }
 


### PR DESCRIPTION
JWTUtils가 bean으로 관리되어 생성자에서 만료시간을 bean등록 최초 시에만 초기화 만료시간 생성 로직을 만들어 토큰 생성전 호출