### PR TITLE
TT-406 actions을 2번 실행해야 하는 버그 해결

### DIFF
--- a/.github/workflows/cd_prod.yml
+++ b/.github/workflows/cd_prod.yml
@@ -102,7 +102,7 @@ jobs:
           echo "${{ secrets.DOCKERHUB_PASSWORD_PROD }}" | sudo docker login -u ${{ secrets.DOCKERHUB_USERNAME_PROD }} --password-stdin
           sudo docker pull ${{ secrets.DOCKERHUB_USERNAME_PROD }}/github-actions-demo
           sudo docker stop $(sudo docker ps -q) 2>/dev/null || true
-          sudo docker run --name github-actions-demo -v logs:/logs -v /usr/bin/ffmpeg:/usr/bin/ffmpeg -v /usr/bin/ffprobe:/usr/bin/ffprobe --rm -d -p 8080:8080 ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-demo
+          sudo docker run --name github-actions-demo --rm -v logs:/logs -d -p 8080:8080 ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-demo
           sudo chmode logs 777
           sudo docker system prune -f 
           EOF

--- a/.github/workflows/cicd_dev.yml
+++ b/.github/workflows/cicd_dev.yml
@@ -105,7 +105,7 @@ jobs:
         echo "${{ secrets.DOCKERHUB_PASSWORD }}" | sudo docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
         sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-demo
         sudo docker stop $(sudo docker ps -q) 2>/dev/null || true
-        sudo docker run --name github-actions-demo -v logs:/logs -v /usr/bin/ffmpeg:/usr/bin/ffmpeg -v /usr/bin/ffprobe:/usr/bin/ffprobe --rm -d -p 8080:8080 ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-demo
+        sudo docker run --name github-actions-demo --rm -v logs:/logs -d -p 8080:8080 ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-demo
         sudo chmode logs 777
         sudo docker system prune -f 
         EOF


### PR DESCRIPTION
docker --rm을 -v 이전에 줘야지 적용