### PR TITLE
TT-422 애플로그인 검증 로직 수정

### DIFF
--- a/src/main/java/com/twentythree/peech/user/dto/IdentityToken.java
+++ b/src/main/java/com/twentythree/peech/user/dto/IdentityToken.java
@@ -1,11 +1,14 @@
 package com.twentythree.peech.user.dto;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-import java.util.List;
+import java.security.PublicKey;
 import java.util.Objects;
 
 @Getter
@@ -17,16 +20,18 @@ public class IdentityToken {
     private IdentityTokenHeader identityTokenHeader;
     private IdentityTokenPayload identityTokenPayload;
 
-    public boolean isVerify(List<ApplePublicKey> publicKeys) {
-        String alg = identityTokenHeader.getAlg();
-        String kid = identityTokenHeader.getKid();
+    public boolean isVerify(String jwt, PublicKey publicKey) {
 
-        for (ApplePublicKey publicKey : publicKeys) {
-            if (publicKey.getKid().equals(alg) && publicKey.getAlg().equals(kid)) {
-                return true;
-            }
+        try {
+            Jws<Claims> jwsClaims = Jwts.parser()
+                    .setSigningKey(publicKey) // 공개 키 설정
+                    .build()
+                    .parseClaimsJws(jwt);
+        } catch (Exception e) {
+            throw new RuntimeException("토큰이 올바르지 못합니다.");
         }
-        return false;
+
+        return true;
     }
 
     @Override

--- a/src/main/java/com/twentythree/peech/user/dto/IdentityTokenPayload.java
+++ b/src/main/java/com/twentythree/peech/user/dto/IdentityTokenPayload.java
@@ -1,5 +1,6 @@
 package com.twentythree.peech.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,6 +12,7 @@ import java.util.Objects;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class IdentityTokenPayload {
      private String iss;
      private Long iat;

--- a/src/main/java/com/twentythree/peech/user/dto/response/ApplePublicKeyResponseDTO.java
+++ b/src/main/java/com/twentythree/peech/user/dto/response/ApplePublicKeyResponseDTO.java
@@ -1,13 +1,52 @@
 package com.twentythree.peech.user.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.twentythree.peech.user.dto.ApplePublicKey;
+import com.twentythree.peech.user.dto.IdentityTokenHeader;
+import io.jsonwebtoken.io.Decoders;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
 import java.util.List;
 
+@Slf4j
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class ApplePublicKeyResponseDTO {
+
+    @JsonProperty("keys")
     private List<ApplePublicKey> applePublicKeys;
+
+    public PublicKey getApplePublicKeyKey(IdentityTokenHeader identityTokenHeader) {
+        String alg = identityTokenHeader.getAlg();
+        String kid = identityTokenHeader.getKid();
+
+        for (ApplePublicKey publicKey : applePublicKeys) {
+            if (publicKey.getKid().equals(kid) && publicKey.getAlg().equals(alg)) {
+
+                byte[] n = Decoders.BASE64URL.decode(publicKey.getN());
+                byte[] e = Decoders.BASE64URL.decode(publicKey.getE());
+                RSAPublicKeySpec publicKeySpec =
+                        new RSAPublicKeySpec(new BigInteger(1, n), new BigInteger(1, e));
+
+                try {
+                    KeyFactory keyFactory = KeyFactory.getInstance(publicKey.getKty());
+                    return keyFactory.generatePublic(publicKeySpec);
+                } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
+                    throw new RuntimeException("응답 받은 Apple Public Key로 PublicKey를 생성할 수 없습니다.");
+                }
+            }
+        }
+
+        throw new RuntimeException("Token을 검증할 수 없습니다.");
+    }
 }

--- a/src/main/java/com/twentythree/peech/user/service/UserServiceImpl.java
+++ b/src/main/java/com/twentythree/peech/user/service/UserServiceImpl.java
@@ -99,7 +99,7 @@ public class UserServiceImpl implements UserService {
 
             ApplePublicKeyResponseDTO publicKeys = appleLoginClient.getPublicKeys();
 
-            if (identityToken.isVerify(publicKeys.getApplePublicKeys())) {
+            if (identityToken.isVerify(socialToken, publicKeys.getApplePublicKeyKey(identityToken.getIdentityTokenHeader()))) {
                 userEmail = identityToken.getIdentityTokenPayload().getEmail();
             } else {
                 throw new Unauthorized("애플로그인에서 토큰이 유효하지 않습니다.");


### PR DESCRIPTION
애플에서 publickey들을 조회

token의 alg와 kid가 같은 publickey를 가져오고 n과e를 이용해 publickey를 생성후 token을 검증