### PR TITLE
fix: TT-459

### DIFF
--- a/src/main/java/com/twentythree/peech/script/controller/ThemeController.java
+++ b/src/main/java/com/twentythree/peech/script/controller/ThemeController.java
@@ -5,8 +5,10 @@ import com.twentythree.peech.script.dto.request.ThemeTitleRequestDTO;
 import com.twentythree.peech.script.dto.response.ThemeIdResponseDTO;
 import com.twentythree.peech.script.dto.response.ThemesResponseDTO;
 import com.twentythree.peech.script.service.ThemeService;
+import com.twentythree.peech.security.jwt.JWTAuthentication;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,5 +38,10 @@ public class ThemeController implements SwaggerThemeInterface {
         Long userId = SecurityContextHolder.getContextHolder().getUserId();
 
         return themeService.getThemesByUserId(userId);
+    }
+
+    @GetMapping("api/v2/theme")
+    public ThemeIdResponseDTO getTheme(@AuthenticationPrincipal JWTAuthentication jwtAuthentication) {
+        return themeService.getThemeByUserId(jwtAuthentication.getUserId());
     }
 }

--- a/src/main/java/com/twentythree/peech/script/domain/ThemeEntity.java
+++ b/src/main/java/com/twentythree/peech/script/domain/ThemeEntity.java
@@ -16,6 +16,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ThemeEntity extends BaseTimeEntity {
 
+    static final String DEFAULT_THEME_TITLE = "default";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "theme_id")
@@ -36,6 +38,10 @@ public class ThemeEntity extends BaseTimeEntity {
 
     public static ThemeEntity of(UserEntity userEntity, String themeTitle) {
         return new ThemeEntity(userEntity, themeTitle);
+    }
+
+    public static ThemeEntity defaultOf(UserEntity userEntity) {
+        return new ThemeEntity(userEntity, DEFAULT_THEME_TITLE);
     }
 
 }

--- a/src/main/java/com/twentythree/peech/script/repository/ThemeRepository.java
+++ b/src/main/java/com/twentythree/peech/script/repository/ThemeRepository.java
@@ -15,4 +15,7 @@ public interface ThemeRepository extends JpaRepository<ThemeEntity, Long> {
 
     @Query("select v from VersionEntity v where v.themeEntity.themeId = :themeId")
     Optional<List<VersionEntity>> findAllVersionsByThemeId(Long themeId);
+
+    @Query("select t.themeId from ThemeEntity t where t.userEntity.id = :userId")
+    Long findThemeIdByUserId(Long userId);
 }

--- a/src/main/java/com/twentythree/peech/script/service/ThemeService.java
+++ b/src/main/java/com/twentythree/peech/script/service/ThemeService.java
@@ -3,10 +3,12 @@ package com.twentythree.peech.script.service;
 import com.twentythree.peech.script.domain.ThemeEntity;
 import com.twentythree.peech.script.domain.VersionEntity;
 import com.twentythree.peech.script.dto.ThemeDTO;
+import com.twentythree.peech.script.dto.response.ThemeIdResponseDTO;
 import com.twentythree.peech.script.dto.response.ThemesResponseDTO;
 import com.twentythree.peech.script.repository.ThemeRepository;
 import com.twentythree.peech.user.entity.UserEntity;
 import com.twentythree.peech.user.repository.UserRepository;
+import com.twentythree.peech.script.validator.ThemeValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +20,7 @@ import java.util.List;
 public class ThemeService {
 
     private final ThemeRepository themeRepository;
+    private final ThemeValidator themeValidator;
     private final UserRepository userRepository;
 
     public Long saveTheme(Long userId, String themeTitle) {
@@ -50,5 +53,24 @@ public class ThemeService {
         }
 
         return new ThemesResponseDTO(themesDTO);
+    }
+
+
+    public ThemeIdResponseDTO getThemeByUserId(Long userId) {
+
+        if(themeRepository.findThemeIdByUserId(userId) == null) {
+            throw new IllegalArgumentException("생성된 기본폴더가 존재하지 않습니다.");
+        }
+
+        return new ThemeIdResponseDTO(themeRepository.findThemeIdByUserId(userId));
+    }
+
+    public void createDefaultFolder(Long userId) {
+        UserEntity userEntity = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+
+        if(themeValidator.existThemeById(userId)){
+            throw new IllegalArgumentException("이미 기본 폴더가 생성되었습니다.");
+        }
+        themeRepository.save(ThemeEntity.defaultOf(userEntity));
     }
 }

--- a/src/main/java/com/twentythree/peech/user/controller/UserController.java
+++ b/src/main/java/com/twentythree/peech/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.twentythree.peech.user.controller;
 
 import com.twentythree.peech.auth.service.SecurityContextHolder;
 import com.twentythree.peech.common.dto.response.WrappedResponseBody;
+import com.twentythree.peech.script.service.ThemeService;
 import com.twentythree.peech.user.domain.UserFetcher;
 import com.twentythree.peech.user.domain.UserMapper;
 import com.twentythree.peech.user.dto.AccessAndRefreshToken;
@@ -34,6 +35,7 @@ public class UserController implements SwaggerUserController{
     private final UserMapper userMapper;
     private final UserFetcher userFetcher;
     private final Logger log = LoggerFactory.getLogger(UserController.class);
+    private final ThemeService themeService;
 
     @Operation(summary = "유저 가입",
             description = "deviceId를 RequestBody에 담아 요청하면 새로운 유저를 생성하고 생성된 UserId를 응답한다.")
@@ -69,7 +71,9 @@ public class UserController implements SwaggerUserController{
         Long userId = SecurityContextHolder.getContextHolder().getUserId();
         log.info("userId : {}", userId);
 
+
         LoginBySocial accessAndRefreshToken = userService.completeProfile(userId,request.getFirstName(), request.getLastName(), request.getNickName(), request.getBirth(), request.getGender(), funnel);
+        themeService.createDefaultFolder(userId);
 
         return ResponseEntity.status(200).body(new UserIdTokenResponseDTO(accessAndRefreshToken.getAccessToken(), accessAndRefreshToken.getRefreshToken()));
     }
@@ -92,8 +96,7 @@ public class UserController implements SwaggerUserController{
     @Operation(summary = "유저 삭제")
     @DeleteMapping("api/v1.1/user")
     public UserDeleteResponseDTO deleteUser() {
-        // TODO 유저 토큰에서 userId 가져오는 코드
-        Long userId = 123L; // 임시 유저
+        Long userId = SecurityContextHolder.getContextHolder().getUserId();
 
         UserDomain userDomain = userService.deleteUser(userId);
         return new UserDeleteResponseDTO(userDomain.getDeleteAt());

--- a/src/main/java/com/twentythree/peech/user/service/UserServiceImpl.java
+++ b/src/main/java/com/twentythree/peech/user/service/UserServiceImpl.java
@@ -4,6 +4,7 @@ import com.twentythree.peech.common.exception.Unauthorized;
 import com.twentythree.peech.common.exception.UserAlreadyExistException;
 import com.twentythree.peech.common.utils.JWTUtils;
 import com.twentythree.peech.common.utils.UserRoleConvertUtils;
+import com.twentythree.peech.script.repository.ThemeRepository;
 import com.twentythree.peech.security.exception.JWTAuthenticationException;
 import com.twentythree.peech.security.exception.LoginExceptionCode;
 import com.twentythree.peech.security.jwt.JWTAuthenticationToken;
@@ -20,6 +21,7 @@ import com.twentythree.peech.user.dto.response.ApplePublicKeyResponseDTO;
 import com.twentythree.peech.user.dto.response.GetUserInformationResponseDTO;
 import com.twentythree.peech.user.entity.UserEntity;
 import com.twentythree.peech.user.repository.UserRepository;
+import com.twentythree.peech.script.validator.ThemeValidator;
 import com.twentythree.peech.user.validator.UserValidator;
 import com.twentythree.peech.user.value.*;
 import lombok.RequiredArgsConstructor;
@@ -49,6 +51,8 @@ public class UserServiceImpl implements UserService {
 
     private final UserValidator userValidator;
     private final JWTUtils jwtUtils;
+    private final ThemeRepository themeRepository;
+    private final ThemeValidator themeValidator;
 
 
     @Override
@@ -173,8 +177,7 @@ public class UserServiceImpl implements UserService {
 
     public GetUserInformationResponseDTO getUserInformation() {
 
-        // TODO context holder에서 id 가져옴
-        Long userId = 1L;
+        Long userId = com.twentythree.peech.auth.service.SecurityContextHolder.getContextHolder().getUserId();
 
         UserDomain userDomain = userFetcher.fetchUser(userId);
         String nickName = userDomain.getNickName();


### PR DESCRIPTION
- 추가 유저 정보 입력시 -> userId, themeId 생성
- themeId를 조회하는 api 요청시 -> 생성된 기본 themeId 반환

추가로 themeId 조회시, 어노테이션 기반으로 ContextHolder에서 userId 꺼내는 방식을 적용해봄