### PR TITLE
TT-493

### DIFF
--- a/src/main/java/com/twentythree/peech/script/cache/RedisTemplateImpl.java
+++ b/src/main/java/com/twentythree/peech/script/cache/RedisTemplateImpl.java
@@ -55,7 +55,6 @@ public class RedisTemplateImpl implements CacheService {
 
             // 해당 문장의 정보를 담아주는 Hash 저장
             redisTemplate.opsForHash().putAll(sentenceId.toString(), sentenceInformations);
-            log.info("Successfully saved redisSentence: {}", redisSentence);
 
         }catch (Exception e) {
             log.error("Error saving redisSentence List: {}",sentenceId,e);

--- a/src/main/java/com/twentythree/peech/script/dto/ParagraphExpectedTimeDTO.java
+++ b/src/main/java/com/twentythree/peech/script/dto/ParagraphExpectedTimeDTO.java
@@ -11,6 +11,6 @@ import java.util.List;
 public class ParagraphExpectedTimeDTO {
 
     private LocalTime time;
-    private List<String> paragraph;
+    private String paragraph;
 
 }

--- a/src/main/java/com/twentythree/peech/script/service/ScriptService.java
+++ b/src/main/java/com/twentythree/peech/script/service/ScriptService.java
@@ -412,7 +412,8 @@ public class ScriptService {
 
         for(List<String> paragraph :  paragraphs) {
             LocalTime paragraphTime = calculateParagraphTime(paragraph);
-            paragraphExpectedTimeDTOList.add(new ParagraphExpectedTimeDTO(paragraphTime, paragraph));
+            String mergedParagraph = String.join(" ", paragraph);
+            paragraphExpectedTimeDTOList.add(new ParagraphExpectedTimeDTO(paragraphTime, mergedParagraph));
             totalExpectedTime = sumLocalTime(totalExpectedTime, paragraphTime);
         }
 


### PR DESCRIPTION
- 예상시간 요청 api 응답값 paragraph 문자열 하나로 받도록 변경
- STT 요청시 Redis 저장 확인 로그 제거
- 스크립트 생성시 잘못된 시간 저장은 DB 서버시간 설정이 잘못되어 있던 것이었어서 수정 후 Ci/Cd reload함